### PR TITLE
Fix: Handle url and name update when name is changed

### DIFF
--- a/knowledge/data-sources/onedrive/main.go
+++ b/knowledge/data-sources/onedrive/main.go
@@ -270,6 +270,8 @@ func saveToMetadata(ctx context.Context, logErr *logrus.Logger, output *Metadata
 		}
 		logErr.Infof("Downloaded %s", relativePath)
 		detail.UpdatedAt = item.GetLastModifiedDateTime().String()
+		detail.URL = *item.GetWebUrl()
+		detail.FilePath = relativePath
 		output.Files[*item.GetId()] = detail
 	} else {
 		logErr.Infof("Skipping %s because it is not changed", relativePath)


### PR DESCRIPTION
When onedrive item is changed with its name, we don't update its name and url. This PR fixes that.