### PR TITLE
fix: trim white-space when extracting env vars from request headers

### DIFF
--- a/browser/src/screenshot.ts
+++ b/browser/src/screenshot.ts
@@ -41,7 +41,7 @@ export async function screenshot (
 
   // Build the download URL used by the UI to display the image
   let downloadUrl: string | undefined
-  const obotServerUrl = getGPTScriptEnv(headers, 'OBOT_SERVER_URL')
+  const obotServerUrl = process.env?.OBOT_SERVER_URL
   const threadId = getGPTScriptEnv(headers, 'OBOT_THREAD_ID')
   if (obotServerUrl !== undefined && threadId !== undefined) {
     downloadUrl = `${obotServerUrl}/api/threads/${threadId}/file/${screenshotName}`

--- a/browser/src/session.ts
+++ b/browser/src/session.ts
@@ -132,18 +132,19 @@ export function getWorkspaceId (headers: IncomingHttpHeaders): string | undefine
 export function getGPTScriptEnv (headers: IncomingHttpHeaders, envKey: string): string | undefined {
   const envHeader = headers?.['x-gptscript-env']
   const envArray = Array.isArray(envHeader) ? envHeader : [envHeader]
+
   for (const env of envArray) {
     if (env == null) {
       continue
     }
 
     for (const pair of env.split(',')) {
-      const [key, value] = pair.split('=')
+      const [key, value] = pair.split('=').map(part => part.trim())
       if (key === envKey) {
-        return value ?? process.env?.[envKey]
+        return value
       }
     }
   }
 
-  return process.env?.[envKey]
+  return undefined
 }


### PR DESCRIPTION
This was causing the `Browser` tool daemon to fail to extract the `OBOT_THREAD_ID` and other environment variables from the `x-gptscript-env` request header and made it fall back to using the environment variable it was started with.


Addresses https://github.com/obot-platform/obot/issues/980