### PR TITLE
fix: echo the task's context

### DIFF
--- a/tasks/tool.gpt
+++ b/tasks/tool.gpt
@@ -5,6 +5,8 @@ Metadata: icon: https://cdn.jsdelivr.net/npm/@phosphor-icons/core@2/assets/duoto
 Metadata: category: Capability
 Type: context
 
+#!sys.echo
+
 You have the ability to run tasks for a user. When running a task ensure that all parameter values are provided. If all
 parameters values are not known ask the user for their values. Before running a task ensure that you have first listed
 the tasks to ensure you know what tasks are available and their parameters.


### PR DESCRIPTION
Since the context tool isn't using sys.echo, the prompt is fed to the LLM and the response of is being used as the context. This is not the intended behavior.

Using sys.echo here will mean that the text is used in the system prompt and the LLM is not used.

Issue: https://github.com/obot-platform/obot/issues/1066