### PR TITLE
chore: give sendgrid its own category

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -1,6 +1,7 @@
 tools:
   sendgrid:
     reference: ./sendgrid
+    all: true
   database:
     reference: ./database
   atlassian-jira:

--- a/sendgrid/tool.gpt
+++ b/sendgrid/tool.gpt
@@ -1,10 +1,10 @@
+---
 Name: SendGrid
-Metadata: category: Capability
-Metadata: icon: https://cdn.jsdelivr.net/npm/@phosphor-icons/core@2/assets/duotone/envelope-duotone.svg
+Metadata: bundle: true
+Description: Tools for interacting with SendGrid.
 Share Tools: Send Email
 
 ---
-
 Name: Send Email
 Description: Send an email using SendGrid.
 Share Context: Send Email Context
@@ -29,3 +29,11 @@ The Send Email tool allows you to send emails using SendGrid.
 - Don't sign the email unless otherwise asked to do so.
 
 # END INSTRUCTIONS: Send Email tool
+
+---
+!metadata:*:category
+SendGrid
+
+---
+!metadata:*:icon
+https://cdn.jsdelivr.net/npm/@phosphor-icons/core@2/assets/duotone/envelope-duotone.svg

--- a/sendgrid/tool.gpt
+++ b/sendgrid/tool.gpt
@@ -36,4 +36,4 @@ SendGrid
 
 ---
 !metadata:*:icon
-https://cdn.jsdelivr.net/npm/@phosphor-icons/core@2/assets/duotone/envelope-duotone.svg
+/admin/assets/sendgrid_icon.svg

--- a/sendgrid/tool.gpt
+++ b/sendgrid/tool.gpt
@@ -8,7 +8,7 @@ Share Tools: Send Email
 Name: Send Email
 Description: Send an email using SendGrid.
 Share Context: Send Email Context
-Credentials: ./credential/tool.gpt
+Credentials: ./credential
 Param: to: A comma-delimited list of email addresses to send the email to.
 Param: subject: The subject of the email.
 Param: html_body: (optional) The HTML body of the email.
@@ -20,13 +20,17 @@ Param: text_body: (optional) The plain text body of the email.
 Name: Send Email Context
 Type: context
 
+#!sys.echo
+
 # START INSTRUCTIONS: Send Email tool
 
 The Send Email tool allows you to send emails using SendGrid.
 
-- At least one of `html_body` or `text_body` must be provided.
-- If both `html_body` and `text_body` are provided, both will be included in the email.
-- Don't sign the email unless otherwise asked to do so.
+When calling the Send Email tool:
+- At least one of `html_body` or `text_body` must be provided
+- If both `html_body` and `text_body` are provided, both will be included in the email
+- An email can be sent to multiple recipients by providing a comma-delimited list of email addresses for the `to` parameter
+- Before sending every email, check the body for placeholder or template text and, when found, prompt the user to resolve them. Afterwards, send the email using the resolved values in the body.
 
 # END INSTRUCTIONS: Send Email tool
 


### PR DESCRIPTION
The `SendGrid` tools should not be in the `Capability` category since they don't integrate with/extend the user UI.

This change: 
- switches `SendGrid` tools to a new, dedicated, category
- switches to the official `SendGrid` icon (depends on https://github.com/obot-platform/obot/pull/1101)
- updates the context to resolve placeholders/templates in body content before sending emails
- updates the context to prefer sending an email to multiple recipients with a single `Send Email` call
