### PR TITLE
feat: add generic user timezone context

### DIFF
--- a/bluesky/tool.gpt
+++ b/bluesky/tool.gpt
@@ -9,7 +9,7 @@ Name: Search Posts
 Description: Search for Bluesky posts
 Credential: ./credential
 JSON Response: true
-Share Context: ../time
+Share Context: Current Date and Time from ../time
 Share Tools: Search Users
 Param: query: A Lucene query to search for posts with.
 Param: since: (optional) ISO 8601 UTC timestamp to search for posts since (inclusive). Defaults to 7 days ago.
@@ -24,7 +24,7 @@ Name: Search Users
 Description: Search for Bluesky users
 Credential: ./credential
 JSON Response: true
-Share Context: ../time
+Share Context: Current Date and Time from ../time
 Param: query: A Lucene query to search for users with.
 Param: limit: (optional) The maximum number of users to return. Must be an integer >=1 and <=100. Defaults to 25.
 
@@ -35,7 +35,7 @@ Name: Create Post
 Description: Create a Bluesky post
 Credential: ./credential
 JSON Response: true
-Share Context: ../time
+Share Context: Current Date and Time from ../time
 Param: text: The text of the post.
 Param: tags: (optional) A comma separated list of tags to add to the post. For example, `#apple,#banana` will add both `#apple` and `#banana` to the post.
 
@@ -46,7 +46,7 @@ Name: Delete Post
 Description: Delete a Bluesky post
 Credential: ./credential
 JSON Response: true
-Share Context: ../time
+Share Context: Current Date and Time from ../time
 Param: post_uri: The URI of the post to delete.
 
 #!/usr/bin/env npm --silent --prefix ${GPTSCRIPT_TOOL_DIR} run tool -- deletePost

--- a/browser/tool.gpt
+++ b/browser/tool.gpt
@@ -118,7 +118,7 @@ Tools: service
 Name: Browser Context
 Metadata: index: false
 Type: context
-Share Context: ../time
+Share Context: Current Date and Time from ../time
 
 #!sys.echo
 

--- a/github/tool.gpt
+++ b/github/tool.gpt
@@ -9,7 +9,7 @@ Name: Search Issues and PRs
 Description: Search for issues and PRs in GitHub. Results are paginated, so in order to get all results for a search, call this function with the `page` parameter incremented by 1 until no results are returned.
 Credential: ./credential
 Share Context: GitHub Context
-Share Contexts: ../time
+Share Contexts: Current Date and Time from ../time
 Tools: github.com/gptscript-ai/datasets/filter
 Param: owner: (optional) the owner of the repository the issues or PRs belong to
 Param: repo: (optional) the name of the repository the issues or PRs belong to
@@ -36,7 +36,7 @@ Name: Create Issue
 Description: Create a new issue in the specified GitHub repository
 Credential: ./credential
 Share Context: GitHub Context
-Share Context: ../time
+Share Context: Current Date and Time from ../time
 Param: owner: the owner of the repository
 Param: repo: the name of the repository
 Param: title: the title of the issue
@@ -113,7 +113,7 @@ Name: Create PR
 Description: Create a new pull request in the specified GitHub repository
 Credential: ./credential
 Share Context: GitHub Context
-Share Context: ../time
+Share Context: Current Date and Time from ../time
 Param: owner: the owner of the repository
 Param: repo: the name of the repository
 Param: title: the title of the pull request

--- a/google/gmail/tool.gpt
+++ b/google/gmail/tool.gpt
@@ -8,7 +8,7 @@ Share Tools: List Inbox, Read Email, Search Emails, Send Email, Delete Email, Li
 Name: List Inbox
 Description: List emails in the user's Gmail inbox
 Credential: ../credential
-Share Contexts: ../../time, Email List Context
+Share Contexts: Current Date and Time from ../../time, Email List Context
 Tools: github.com/gptscript-ai/datasets/filter
 Param: max_results: Maximum number of emails to list (Optional: Default will list 100 emails in the inbox)
 
@@ -28,7 +28,7 @@ Param: email_subject: Email subject to read (Optional: If not provided, email_id
 Name: Search Emails
 Description: Search a user's Gmail account for emails. Will return the email_id for each message. Can also be used to list emails in a folder or with a label.
 Credential: ../credential
-Share Contexts: ../../time
+Share Contexts: Current Date and Time from ../../time
 Tools: github.com/gptscript-ai/datasets/filter
 Param: query: Search query to find emails in the user's Gmail account. Uses Gmail search syntax (e.g., "from:someuser@example.com rfc822msgid:<somemsgid@example.com> is:unread")
 Param: max_results: Maximum number of emails to list (Optional: Default will list 100 emails that match the query)
@@ -39,7 +39,7 @@ Param: max_results: Maximum number of emails to list (Optional: Default will lis
 Name: Send Email
 Description: Send an email from the user's Gmail account. Do not attempt to forward or reply to emails using this tool.
 Credential: ../credential
-Share Context: ../../time
+Share Context: Current Date and Time from ../../time
 Param: to_emails: A comma separated list of email addresses to send the email to
 Param: cc_emails: A comma separated list of email addresses to cc the email to (Optional)
 Param: bcc_emails: A comma separated list of email addresses to bcc the email to (Optional)
@@ -61,7 +61,7 @@ Param: email_id: The ID of the email to delete
 Name: List Drafts
 Description: List drafts in a user's Gmail account
 Credential: ../credential
-Share Contexts: ../../time, Email List Context
+Share Contexts: Current Date and Time from ../../time, Email List Context
 Tools: github.com/gptscript-ai/datasets/filter
 Param: max_results: Maximum number of drafts to list (Optional: Default will list 100 drafts)
 Param: attachments: A comma separated list of workspace file paths to attach to the email (Optional)
@@ -72,7 +72,7 @@ Param: attachments: A comma separated list of workspace file paths to attach to 
 Name: Create Draft
 Description: Create a draft email in a user's Gmail account.
 Credential: ../credential
-Share Context: ../../time
+Share Context: Current Date and Time from ../../time
 Share Context: Draft Context
 Param: to_emails: A comma separated list of email addresses to send the email to
 Param: cc_emails: A comma separated list of email addresses to cc the email to (Optional)

--- a/google/search/tool.gpt
+++ b/google/search/tool.gpt
@@ -8,7 +8,7 @@ Share Tools: Search
 Name: Search
 Description: Search Google with a given query and return relevant information from the search results. Search with more maxResults if you need more information.
 JSON Response: true
-Share Context: ../../time
+Share Context: Current Date and Time from ../../time
 Tools: service
 Args: query: A question, statement, or topic to search with (required)
 Args: maxResults: The maximum number of search results to gather relevant information from (optional, default 3, minimum 2)

--- a/index.yaml
+++ b/index.yaml
@@ -51,6 +51,7 @@ tools:
     all: true
   time:
     reference: ./time
+    all: true
   workspace-files:
     reference: ./workspace-files
   tasks:

--- a/outlook/calendar/tool.gpt
+++ b/outlook/calendar/tool.gpt
@@ -136,7 +136,7 @@ Credential: ./credential
 ---
 Name: Outlook Calendar Context
 Type: context
-Share Context: ../../time
+Share Context: Current Date and Time from ../../time
 Share Tools: Get Default Timezone
 
 #!sys.echo

--- a/outlook/mail/tool.gpt
+++ b/outlook/mail/tool.gpt
@@ -113,7 +113,7 @@ Credential: ./credential
 ---
 Name: Outlook Mail Context
 Type: context
-Share Context: ../../time
+Share Context: Current Date and Time from ../../time
 Share Tools: Get Default Timezone
 
 #!sys.echo

--- a/slack/tool.gpt
+++ b/slack/tool.gpt
@@ -183,7 +183,7 @@ Credential: ./credential
 ---
 Name: Slack Context
 Type: context
-Share Context: ../time
+Share Context: Current Date and Time from ../time
 Share Tools: User Context
 
 #!sys.echo

--- a/time/tool.gpt
+++ b/time/tool.gpt
@@ -1,3 +1,10 @@
+---
+Name: Time
+Description: Context tools that expose information about the current time, date, and timezone for the user.
+Metadata: bundle: true
+Share Contexts: Current Date and Time, User Timezone
+
+---
 Name: Current Date and Time
 Description: Context that provides the current date and time in ISO 8601 format.
 Type: context
@@ -6,6 +13,18 @@ Type: context
 from datetime import datetime, timezone
 
 print("The current date and time is ", datetime.now(timezone.utc).isoformat())
+
+---
+Name: User Timezone
+Description: Context that provides the IANA Time Zone ID for the user's preferred time zone.
+Type: context
+
+#!python3
+
+import os
+
+timezone = os.getenv('OBOT_USER_TIMEZONE', 'UTC')
+print(f"The user's preferred time zone is {timezone}")
 
 ---
 !metadata:*:category


### PR DESCRIPTION
- Add the `User Timezone` context tool that exposes the user's preferred timezone provided by the `OBOT_USER_TIMEZONE` environment variable injected by Obot (depends on https://github.com/obot-platform/obot/pull/1107)
- Add a `Time` bundle that includes the `Get Current Date and Time` and `User Timezone` context tools
  
Addresses https://github.com/obot-platform/obot/issues/1111