### PR TITLE
Chore: increase the scraping limit to 2000

### DIFF
--- a/knowledge/data-sources/website/main.go
+++ b/knowledge/data-sources/website/main.go
@@ -65,7 +65,7 @@ func main() {
 	}
 
 	if input.Limit == 0 {
-		input.Limit = getFromEnvOrDefault("OBOT_WEBSCRAPER_LIMIT", 250)
+		input.Limit = getFromEnvOrDefault("OBOT_WEBSCRAPER_LIMIT", 2000)
 	}
 
 	output := MetadataOutput{}


### PR DESCRIPTION
As we are increasing the reliability of the ingestion process, we can increase the number of the limit when scraping.