### PR TITLE
enhance: add a tool to download content from a given url

### DIFF
--- a/browser/package-lock.json
+++ b/browser/package-lock.json
@@ -8,6 +8,7 @@
         "@gptscript-ai/gptscript": "https://github.com/gptscript-ai/node-gptscript#306861b8b5aea2ea0481c180067a1687d2726530",
         "@types/turndown": "^5.0.4",
         "async-mutex": "^0.5.0",
+        "axios": "^1.7.9",
         "body-parser": "^1.20.2",
         "cheerio": "1.0.0-rc.12",
         "env-paths": "^3.0.0",
@@ -1337,6 +1338,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.7.9",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.9.tgz",
+      "integrity": "sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/balanced-match": {
@@ -2887,6 +2899,26 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/for-each": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
@@ -4385,6 +4417,12 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
     },
     "node_modules/punycode": {
       "version": "2.3.1",

--- a/browser/package.json
+++ b/browser/package.json
@@ -20,6 +20,7 @@
     "@gptscript-ai/gptscript": "https://github.com/gptscript-ai/node-gptscript#306861b8b5aea2ea0481c180067a1687d2726530",
     "@types/turndown": "^5.0.4",
     "async-mutex": "^0.5.0",
+    "axios": "^1.7.9",
     "body-parser": "^1.20.2",
     "cheerio": "1.0.0-rc.12",
     "env-paths": "^3.0.0",

--- a/browser/src/download.ts
+++ b/browser/src/download.ts
@@ -1,0 +1,48 @@
+import axios from 'axios'
+import { GPTScript } from '@gptscript-ai/gptscript'
+import { getWorkspaceId, getGPTScriptEnv } from './session.ts'
+import { type IncomingHttpHeaders } from 'node:http'
+
+const client = new GPTScript()
+
+export interface DownloadInfo {
+  url: string
+  resolvedUrl: string
+  contentType?: string
+  workspaceFile: string
+  downloadedAt: number
+}
+
+export async function download(
+  headers: IncomingHttpHeaders,
+  url: string,
+  fileName: string
+): Promise<DownloadInfo> {
+  const downloadedAt = Date.now()
+
+  try {
+    const workspaceId = getWorkspaceId(headers)
+    const workspaceFile = workspaceId !== undefined ? `files/${fileName}` : fileName
+
+    // Configure axios to follow redirects with a limit
+    const response = await axios.get(url, {
+      responseType: 'arraybuffer',
+      maxRedirects: 5, // Set maximum redirects to follow
+      validateStatus: (status) => status >= 200 && status < 400, // Allow redirects (3xx)
+    })
+
+    const contentType = response.headers['content-type']
+    await client.writeFileInWorkspace(workspaceFile, Buffer.from(response.data), workspaceId)
+
+    return { 
+        url,
+        resolvedUrl: response.request.res.responseUrl || url,
+        contentType,
+        workspaceFile,
+        downloadedAt
+    } // Use the final URL after redirects
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err)
+    throw new Error(`Error downloading content from ${url}: ${msg}`)
+  }
+}

--- a/browser/tool.gpt
+++ b/browser/tool.gpt
@@ -2,7 +2,7 @@ Name: Browser
 Description: Tools to navigate websites using a browser.
 Metadata: bundle: true
 Credentials: github.com/gptscript-ai/credentials/model-provider
-Share Tools: Browse, Get Page Contents, Filter, Fill, Enter, Scroll, Back, Forward, Screenshot
+Share Tools: Browse, Get Page Contents, Filter, Fill, Enter, Scroll, Back, Forward, Screenshot, Download
 
 ---
 Name: Get Page Contents
@@ -26,7 +26,6 @@ Params: tabID: (optional) The ID of the tab. If unspecified, a new tab will be c
 Params: followMode: (optional) If true, the tool will produce a screenshot of the final page state. Defaults to false.
 
 #!http://service.daemon.gptscript.local/browse
-
 
 ---
 Name: Filter
@@ -115,6 +114,33 @@ Tools: service
 #!http://service.daemon.gptscript.local/forward
 
 ---
+Name: Download
+Share Context: Download Context
+Tools: service
+Description: Downloads the content from an HTTP/HTTPS URL and saves it to the workspace.
+Params: url: (required) The URL of the content to download.
+Params: fileName: (required) The name of the workspace file to save the content to.
+
+#!http://service.daemon.gptscript.local/download
+
+---
+Name: Download Context
+Metadata: index: false
+Type: context
+
+#!sys.echo
+
+START TOOL USAGE: Download
+
+The `Download` tool saves the content from any HTTP or HTTPS URL to a file in the workspace. It can be used to download any well formed HTTP or HTTPS URL, including URLs to web pages, files, and API endpoints.
+
+The tool returns A JSON object that contains the `url`, `resolvedUrl`, `contentType`, `workspaceFile`, and `downloadedAt` fields. The `resolvedUrl` is the final URL after any redirects.
+
+Do not attempt to link to a `workspaceFile` when displaying the results of a `Download` tool call.
+
+END TOOL USAGE: Download
+
+---
 Name: Browser Context
 Metadata: index: false
 Type: context
@@ -153,7 +179,6 @@ Screenshots can only be displayed to the user by embedding their `imageDownloadU
 When the `screenshotInfo` field is present in tool response, ALWAYS stop what you're doing and display the respective screenshot to the user immediately before continuing.
 
 END TOOL USAGE: The `screenshotInfo` response field
-
 
 ---
 Name: service


### PR DESCRIPTION
Add a `Download` tool to the `Browser` bundle that adds support for downloading
content from a given HTTP/S URL to a workspace file.

Addresses https://github.com/obot-platform/obot/issues/1132

