### PR TITLE
fix: fall back to utc for invalid timezones

### DIFF
--- a/time/tool.gpt
+++ b/time/tool.gpt
@@ -10,12 +10,21 @@ Description: Context that provides the current date and time in ISO 8601 format.
 Type: context
 
 #!python3
+
 import os
 from datetime import datetime
 from zoneinfo import ZoneInfo
 
-timezone = ZoneInfo(os.getenv('OBOT_USER_TIMEZONE', 'UTC'))
-print(f"The current local date and time for the user is {datetime.now(timezone).isoformat()}")
+# Retrieve the timezone or use 'UTC' as a default
+obot_user_timezone = os.getenv('OBOT_USER_TIMEZONE', 'UTC').strip()
+
+try:
+    timezone = ZoneInfo(obot_user_timezone)
+except ValueError:
+    # Invalid timezone, fallback to UTC
+    timezone = ZoneInfo('UTC')
+
+print(f"The current local date and time for the user is {datetime.now(timezone).isoformat()}.")
 
 ---
 Name: User Timezone
@@ -25,9 +34,18 @@ Type: context
 #!python3
 
 import os
+from zoneinfo import ZoneInfo
 
-timezone = os.getenv('OBOT_USER_TIMEZONE', 'UTC')
-print(f"The user's preferred time zone is {timezone}.")
+# Retrieve the timezone or use 'UTC' as a default
+obot_user_timezone = os.getenv('OBOT_USER_TIMEZONE', 'UTC').strip()
+
+try:
+    timezone = ZoneInfo(obot_user_timezone)
+except ValueError:
+    # Invalid timezone, fallback to UTC
+    timezone = ZoneInfo('UTC')
+
+print(f"The user's preferred time zone is {timezone.key}.")
 
 ---
 !metadata:*:category


### PR DESCRIPTION
In some situations the `Current Date and Time` context tool is called without `OBOT_USER_TIMEZONE` environment being set by Obot, causing the call to fail with an invalid timezone error. In particular, this happens when configuring agent-scoped auth for tools
that share `Current Date and Time`, and breaks the feature.

To fix this, parse the timezone in the `Current Date and Time` and `User Timezone` tools and fall back to UTC when it's invalid.

Addresses https://github.com/obot-platform/obot/issues/1157

