### PR TITLE
enhance: use credentials to capture sendgrid email address

### DIFF
--- a/sendgrid/credential/tool.gpt
+++ b/sendgrid/credential/tool.gpt
@@ -1,6 +1,11 @@
 
-Name: SendGrid API Key
-Share Credential: github.com/gptscript-ai/credential as sendgrid
+Name: SendGrid Credentials
+Description: Credentials for the SendGrid API
+Share Credential: github.com/gptscript-ai/credential as sendgrid.key
     with "Please enter your SendGrid API key" as message and
-    token as field and
+    key as field and
     SENDGRID_API_KEY as env
+Share Credential: github.com/gptscript-ai/credential as sendgrid.address
+    with "Please enter your SendGrid email address" as message and
+    address as field and
+    SENDGRID_EMAIL_ADDRESS as env

--- a/sendgrid/main.go
+++ b/sendgrid/main.go
@@ -23,24 +23,18 @@ func main() {
 	)
 	switch command {
 	case "sendEmail":
-		// Retrieve environment variables for sending email
-		to := os.Getenv("TO")
-		subject := os.Getenv("SUBJECT")
-		textBody := os.Getenv("TEXT_BODY")
-		htmlBody := os.Getenv("HTML_BODY")
-
-		// Validate required fields
-		if to == "" || subject == "" || (textBody == "" && htmlBody == "") {
-			fmt.Println("Missing required environment variables: TO, SUBJECT, and at least one of TEXT_BODY or HTML_BODY")
-			os.Exit(1)
-		}
-
-		// Call the Send function
-		result, err = cmd.Send(ctx, to, subject, textBody, htmlBody)
+		result, err = cmd.Send(ctx,
+			os.Getenv("SENDGRID_API_KEY"),
+			os.Getenv("SENDGRID_EMAIL_ADDRESS"),
+			os.Getenv("FROM_NAME"),
+			os.Getenv("TO"),
+			os.Getenv("SUBJECT"),
+			os.Getenv("TEXT_BODY"),
+			os.Getenv("HTML_BODY"),
+		)
 
 	default:
-		fmt.Printf("Unknown command: %s\n", command)
-		os.Exit(1)
+		err = fmt.Errorf("unknown command: %s", command)
 	}
 
 	if err != nil {

--- a/sendgrid/tool.gpt
+++ b/sendgrid/tool.gpt
@@ -9,8 +9,9 @@ Name: Send Email
 Description: Send an email using SendGrid.
 Share Context: Send Email Context
 Credentials: ./credential
-Param: to: A comma-delimited list of email addresses to send the email to.
 Param: subject: The subject of the email.
+Param: to: A comma-delimited list of email addresses to send the email to.
+Param: from_name: (optional) The display name of the sender of the email. Defaults to "Obot".
 Param: html_body: (optional) The HTML body of the email.
 Param: text_body: (optional) The plain text body of the email.
 
@@ -30,7 +31,7 @@ When calling the Send Email tool:
 - At least one of `html_body` or `text_body` must be provided
 - If both `html_body` and `text_body` are provided, both will be included in the email
 - An email can be sent to multiple recipients by providing a comma-delimited list of email addresses for the `to` parameter
-- Before sending every email, check the body for placeholder or template text and, when found, prompt the user to resolve them. Afterwards, send the email using the resolved values in the body.
+- Before sending every email, check the body for placeholder or template text and, when found, prompt the user to resolve them. Afterwards, send the email using the resolved values in the body
 
 # END INSTRUCTIONS: Send Email tool
 


### PR DESCRIPTION
Email addresses and API keys are tightly coupled for the `SendGrid` API; i.e. you can only send emails from authorized addresses associated with the key you're using.

To codify this relationship in the `SendGrid` tool, share an additional credential to capture the email address alongside the API key.

Additionally, add an optional `from_name` parameter to the `Send Email` tool to support for setting the sender name. Default's to `Obot` if not set.

