### PR TITLE
fix: correct metadata oauth for google search tool

### DIFF
--- a/google/search/tool.gpt
+++ b/google/search/tool.gpt
@@ -31,4 +31,4 @@ Google Search
 
 ---
 !metadata:*:oauth
-search
+google


### PR DESCRIPTION
* should be "google" not "search" 🤦‍♀️ Apologies!