### PR TITLE
fix: remove list todays events tool from outlook calendar

### DIFF
--- a/outlook/calendar/main.go
+++ b/outlook/calendar/main.go
@@ -26,14 +26,6 @@ func main() {
 			fmt.Println(err)
 			os.Exit(1)
 		}
-	case "listEventsToday":
-		now := time.Now()
-		start := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
-		end := time.Date(now.Year(), now.Month(), now.Day(), 23, 59, 59, 0, now.Location())
-		if err := commands.ListEvents(context.Background(), start, end); err != nil {
-			fmt.Println(err)
-			os.Exit(1)
-		}
 	case "listEvents":
 		start, end, err := parseStartEnd(os.Getenv("START"), os.Getenv("END"), false)
 		if err != nil {

--- a/outlook/calendar/tool.gpt
+++ b/outlook/calendar/tool.gpt
@@ -2,7 +2,7 @@
 Name: Outlook Calendar
 Metadata: bundle: true
 Description: Tools for interacting with Microsoft Outlook Calendar.
-Share Tools: List Calendars, List Events Today, List Events, Get Event Details, Create Event, Invite User To Event, Delete Event, Search Events, Respond To Event
+Share Tools: List Calendars, List Events, Get Event Details, Create Event, Invite User To Event, Delete Event, Search Events, Respond To Event
 
 ---
 Name: List Calendars
@@ -11,15 +11,6 @@ Share Context: Outlook Calendar Context
 Credential: ./credential
 
 #!${GPTSCRIPT_TOOL_DIR}/bin/gptscript-go-tool listCalendars
-
----
-Name: List Events Today
-Description: List all events for today in all calendars available to the user.
-Share Context: Outlook Calendar Context
-Tools: github.com/gptscript-ai/datasets/filter
-Credential: ./credential
-
-#!${GPTSCRIPT_TOOL_DIR}/bin/gptscript-go-tool listEventsToday
 
 ---
 Name: List Events
@@ -139,15 +130,9 @@ You have access to tools for the Microsoft Outlook Calendar API.
 
 Do not output calendar IDs or event IDs because they are not helpful for the user.
 
-If creating a date/time in the UTC timezone, it must end with 'Z' to properly denote it's for UTC.
+Convert all dates and times to the user's local timezone before determining if you should include them in the response to the user. Always display events to the user in their preferred timezone unless otherwise specified by the user.
 
-Display all dates and times in the user's preferred timezone.
-
-When the user uses relative terms like "today", "tomorrow", or "last week", assume the date is the current day in the user's preferred timezone.
-
-When the user asks you to create or modify events, assume that any dates or times they provide are in their preferred timezone unless otherwise stated.
-
-Ensure dates and times are converted properly to the user's default timezone when displaying them to the user.
+When the user asks to create or modify events, assume that any dates or times they provide are in their preferred timezone unless otherwise stated by the user.
 
 When listing events from different calendars and/or groups, show them grouped together and labeled using the name of the calender owner so that the user knows which calendar or group the event is from.
 


### PR DESCRIPTION
Remove the `List Todays Events` tool from the `Outlook Calendar` bundle.

The tool is not user timezone aware and the LLM can use `List Events` to
query for the same information by setting start and end arguments based
on the user's timezone.

Addresses https://github.com/obot-platform/obot/issues/508

Note: I'm still running into an edge-case here where the LLM omits events where the UTC date falls outside the current date in the user's local timezone. I haven't figured out how to tweak the context so that the LLM won't make this mistake. I suspect we'll have to plumb the timezone into the actual tool calls and convert the start and end dates to the user's timezone before returning the elements to the user.
