### PR TITLE
enhance: use more descriptive names for database tools

### DIFF
--- a/database/main.go
+++ b/database/main.go
@@ -76,17 +76,17 @@ func main() {
 	// Run the requested command
 	var result string
 	switch command {
-	case "listTables":
-		result, err = cmd.ListTables(ctx, db)
-	case "exec":
-		result, err = cmd.Exec(ctx, db, os.Getenv("STATEMENT"))
+	case "listDatabaseTables":
+		result, err = cmd.ListDatabaseTables(ctx, db)
+	case "execDatabaseStatement":
+		result, err = cmd.ExecDatabaseStatement(ctx, db, os.Getenv("STATEMENT"))
 		if err == nil {
 			err = saveWorkspaceDB(ctx, g, dbWorkspacePath, dbFile, initialDBData)
 		}
-	case "query":
-		result, err = cmd.Query(ctx, db, os.Getenv("QUERY"))
-	case "context":
-		result, err = cmd.Context(ctx, db)
+	case "runDatabaseQuery":
+		result, err = cmd.RunDatabaseQuery(ctx, db, os.Getenv("QUERY"))
+	case "databaseContext":
+		result, err = cmd.DatabaseContext(ctx, db)
 	default:
 		err = fmt.Errorf("unknown command: %s", command)
 	}

--- a/database/pkg/cmd/context.go
+++ b/database/pkg/cmd/context.go
@@ -7,16 +7,17 @@ import (
 	"strings"
 )
 
-// Context returns the context text for the SQLite tools.
+// DatabaseContext returns the context text for the SQLite tools.
 // The resulting string contains all of schemas in the database.
-func Context(ctx context.Context, db *sql.DB) (string, error) {
+func DatabaseContext(ctx context.Context, db *sql.DB) (string, error) {
 	// Build the markdown output
 	var out strings.Builder
 	out.WriteString(`# START INSTRUCTIONS: Database Tools
 
 You have access to tools for interacting with a SQLite database.
-The Exec tool only accepts valid SQLite3 statements.
-The Query tool only accepts valid SQLite3 queries.
+The "List Database Tables" tool returns a list of tables in the database.
+The "Exec Database Statement" tool only accepts valid SQLite3 statements.
+The "Run Database Query" tool only accepts valid SQLite3 queries.
 Display all results from these tools and their schemas in markdown format.
 If the user refers to creating or modifying tables assume they mean a SQLite3 table and not writing a table
 in a markdown file.

--- a/database/pkg/cmd/exec.go
+++ b/database/pkg/cmd/exec.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 )
 
-// Exec executes a SQL statement (e.g., INSERT, UPDATE, DELETE, CREATE) and returns a status message.
-func Exec(ctx context.Context, db *sql.DB, stmt string) (string, error) {
+// ExecDatabaseStatement executes a SQL statement (e.g., INSERT, UPDATE, DELETE, CREATE) and returns a status message.
+func ExecDatabaseStatement(ctx context.Context, db *sql.DB, stmt string) (string, error) {
 	_, err := db.ExecContext(ctx, stmt)
 	if err != nil {
 		return "", fmt.Errorf("error executing SQL: %w", err)

--- a/database/pkg/cmd/query.go
+++ b/database/pkg/cmd/query.go
@@ -12,8 +12,8 @@ type Output struct {
 	Rows    []map[string]any `json:"rows"`
 }
 
-// Query executes a SQL query (e.g., SELECT) and returns the result formatted in JSON
-func Query(ctx context.Context, db *sql.DB, query string) (string, error) {
+// RunDatabaseQuery executes a SQL query (e.g. SELECT) and returns a JSON object containing the results.
+func RunDatabaseQuery(ctx context.Context, db *sql.DB, query string) (string, error) {
 	if query == "" {
 		return "", fmt.Errorf("empty query")
 	}

--- a/database/pkg/cmd/table.go
+++ b/database/pkg/cmd/table.go
@@ -7,7 +7,8 @@ import (
 	"fmt"
 )
 
-func ListTables(ctx context.Context, db *sql.DB) (string, error) {
+// ListDatabaseTables returns a JSON object containing the list of tables in the database.
+func ListDatabaseTables(ctx context.Context, db *sql.DB) (string, error) {
 	tables, err := listTables(ctx, db)
 	if err != nil {
 		return "", fmt.Errorf("failed to list tables: %w", err)

--- a/database/tool.gpt
+++ b/database/tool.gpt
@@ -3,32 +3,32 @@ Name: Database
 Description: Tools for interacting with a database
 Metadata: category: Capability
 Metadata: icon: https://cdn.jsdelivr.net/npm/@phosphor-icons/core@2/assets/duotone/database-duotone.svg
-Share Tools: Query, Exec
+Share Tools: Run Database Query, Exec Database Statement
 
 ---
-Name: Tables
-Description: List all tables in the SQLite database and return the results in markdown format
+Name: List Database Tables
+Description: List all tables in the SQLite database and return a JSON object containing the results
 
-#!${GPTSCRIPT_TOOL_DIR}/bin/gptscript-go-tool listTables
+#!${GPTSCRIPT_TOOL_DIR}/bin/gptscript-go-tool listDatabaseTables
 
 ---
-Name: Query
-Description: Run a SQL query against the SQLite database and return the results in markdown format
+Name: Run Database Query
+Description: Run a SQL query against the SQLite database and return a JSON object containing the results
 Share Context: Database Context
 Param: query: SQL query to run
 
-#!${GPTSCRIPT_TOOL_DIR}/bin/gptscript-go-tool query
+#!${GPTSCRIPT_TOOL_DIR}/bin/gptscript-go-tool runDatabaseQuery
 
 ---
-Name: Exec
+Name: Exec Database Statement
 Description: Execute a SQL statement against the SQLite database
 Share Context: Database Context
 Param: statement: SQL statement to execute
 
-#!${GPTSCRIPT_TOOL_DIR}/bin/gptscript-go-tool exec
+#!${GPTSCRIPT_TOOL_DIR}/bin/gptscript-go-tool execDatabaseStatement
 
 ---
 Name: Database Context
 Type: context
 
-#!${GPTSCRIPT_TOOL_DIR}/bin/gptscript-go-tool context
+#!${GPTSCRIPT_TOOL_DIR}/bin/gptscript-go-tool databaseContext


### PR DESCRIPTION
To reduce confusion in both the LLM and tool maintainers, rename the following tools in the `Database` bundle:

1. `Tables` -> `List Database Tables`
2. `Exec` -> `Exec Database Statement`
3. `Query` -> `Run Database Query`

Also fix tool descriptions to reflect the change from raw markdown output to JSON.

Addresses https://github.com/obot-platform/obot/issues/1208

Since these tools are in the `Capability` category, the "blast radius" of this change includes [the `TableHandler` implementation in obot](https://github.com/obot-platform/obot/blob/31ceab62d455bd798a069be034ea8effb1b41ac4/ui/user/src/lib/components/navbar/Tables.svelte#L8) and all tools/agents currently using them. That being the case, we
should hold-off on merging this change until the `TableHandler` implementation has been updated to the new tool names, or I keep duplicate tools that have the old names around until the handler implementation is updated.
