### PR TITLE
chore: add noAuth metadata to tools that need it

### DIFF
--- a/anthropic-bedrock-model-provider/tool.gpt
+++ b/anthropic-bedrock-model-provider/tool.gpt
@@ -3,6 +3,7 @@ Description: Model provider for AWS Bedrock hosted Anthropic models
 Metadata: envVars: OBOT_ANTHROPIC_BEDROCK_MODEL_PROVIDER_ACCESS_KEY_ID,OBOT_ANTHROPIC_BEDROCK_MODEL_PROVIDER_SECRET_ACCESS_KEY,OBOT_ANTHROPIC_BEDROCK_MODEL_PROVIDER_REGION,OBOT_ANTHROPIC_BEDROCK_MODEL_PROVIDER_SESSION_TOKEN
 Model Provider: true
 Credential: ../model-provider-credential as anthropic-bedrock-model-provider
+Metadata: noUserAuth: anthropic-bedrock-model-provider
 
 
 #!sys.daemon /usr/bin/env python3 ${GPTSCRIPT_TOOL_DIR}/main.py

--- a/anthropic-model-provider/tool.gpt
+++ b/anthropic-model-provider/tool.gpt
@@ -3,6 +3,7 @@ Description: Model provider for Anthropic hosted Claude3 models
 Metadata: envVars: OBOT_ANTHROPIC_MODEL_PROVIDER_API_KEY
 Model Provider: true
 Credential: ../model-provider-credential as anthropic-model-provider
+Metadata: noUserAuth: anthropic-model-provider
 
 #!sys.daemon /usr/bin/env python3 ${GPTSCRIPT_TOOL_DIR}/main.py
 

--- a/azure-openai-model-provider/tool.gpt
+++ b/azure-openai-model-provider/tool.gpt
@@ -4,6 +4,7 @@ Metadata: envVars: OBOT_AZURE_OPENAI_MODEL_PROVIDER_ENDPOINT,OBOT_AZURE_OPENAI_M
 Metadata: optionalEnvVars: OBOT_AZURE_OPENAI_MODEL_PROVIDER_API_VERSION=2024-10-21
 Model Provider: true
 Credential: ../model-provider-credential as azure-openai-model-provider
+Metadata: noUserAuth: azure-openai-model-provider
 
 #!sys.daemon /usr/bin/env python3 ${GPTSCRIPT_TOOL_DIR}/main.py
 

--- a/browser/tool.gpt
+++ b/browser/tool.gpt
@@ -3,6 +3,7 @@ Description: Tools to navigate websites using a browser.
 Metadata: bundle: true
 Credentials: github.com/gptscript-ai/credentials/model-provider
 Share Tools: Browse, Get Page Contents, Filter, Fill, Enter, Scroll, Back, Forward, Screenshot, Download File From URL
+Metadata: noUserAuth: sys.model.provider.credential
 
 ---
 Name: Get Page Contents

--- a/deepseek-model-provider/tool.gpt
+++ b/deepseek-model-provider/tool.gpt
@@ -3,6 +3,7 @@ Description: Model Provider for DeepSeek
 Metadata: envVars: OBOT_DEEPSEEK_MODEL_PROVIDER_API_KEY
 Model Provider: true
 Credential: ../model-provider-credential as deepseek-model-provider
+Metadata: noUserAuth: deepseek-model-provider
 
 #!sys.daemon ${GPTSCRIPT_TOOL_DIR}/bin/gptscript-go-tool
 

--- a/google/youtube/tool.gpt
+++ b/google/youtube/tool.gpt
@@ -11,6 +11,7 @@ Credential: github.com/gptscript-ai/credentials/model-provider
 Tool: github.com/gptscript-ai/datasets/filter
 Param: video_url: The URL of a YouTube video. (e.g. URLs in the form https://www.youtube.com/watch?v=<VIDEO_ID>, https://youtu.be/<VIDEO_ID>, or https://www.youtube.com/live/<VIDEO_ID>).
 Param: model: (Optional) The name of the model to use when cleaning up and summarizing the transcript. Defaults to "gpt-4o".
+Metadata: noUserAuth: sys.model.provider.credential
 
 #!/usr/bin/env python3 ${GPTSCRIPT_TOOL_DIR}/transcriber.py
 

--- a/groq-model-provider/tool.gpt
+++ b/groq-model-provider/tool.gpt
@@ -3,6 +3,7 @@ Description: Model provider for models running on Groq
 Metadata: envVars: OBOT_GROQ_MODEL_PROVIDER_API_KEY
 Model Provider: true
 Credential: ../model-provider-credential as groq-model-provider
+Metadata: noUserAuth: groq-model-provider
 
 #!sys.daemon /usr/bin/env python3 ${GPTSCRIPT_TOOL_DIR}/main.py
 

--- a/images/tool.gpt
+++ b/images/tool.gpt
@@ -8,6 +8,7 @@ Share Tools: Analyze Images, Generate Images
 Name: Analyze Images
 Description: Analyze images using a given prompt and return relevant information about the images
 Credential: github.com/gptscript-ai/credentials/model-provider
+Metadata: noUserAuth: sys.model.provider.credential
 Share Context: Analyze Images Context
 Param: prompt: (optional) A prompt to analyze the images with (defaults "Provide a brief description of each image")
 Param: images: (required) A JSON array containing one or more URLs or file paths of images to analyze. Only supports jpeg, png, and webp.
@@ -18,6 +19,7 @@ Param: images: (required) A JSON array containing one or more URLs or file paths
 Name: Generate Images
 Description: Generate images based on a given prompt
 Credential: github.com/gptscript-ai/credentials/model-provider
+Metadata: noUserAuth: sys.model.provider.credential
 Share Context: Generate Images Context
 Param: prompt: (required) Text describing the images to generate
 Param: size: (optional) Dimensions of the images to generate in. One of [1024x1024, 256x256, 512x512, 1792x1024, 1024x1792] (default 1024x1024)

--- a/knowledge/ingest.gpt
+++ b/knowledge/ingest.gpt
@@ -4,5 +4,6 @@ Credential: github.com/gptscript-ai/credentials/model-provider
 Credential: ../existing-credential as knowledge
 Params: Input: Input File
 Params: Dataset: Dataset ID
+Metadata: noUserAuth: sys.model.provider.credential,knowledge
 
 #!${GPTSCRIPT_TOOL_DIR}/bin/gptscript-go-tool ingest --flows-file=blueprint:obot --dataset ${DATASET} "ws://${INPUT}"

--- a/knowledge/load.gpt
+++ b/knowledge/load.gpt
@@ -5,5 +5,6 @@ Params: Output: Output File
 Params: know_load_metadata: Comma-delimited key=value pairs to be added to the metadata of the loaded document.
 Credential: github.com/gptscript-ai/credentials/model-provider
 Credential: ../existing-credential as knowledge
+Metadata: noUserAuth: sys.model.provider.credential,knowledge
 
 #!${GPTSCRIPT_TOOL_DIR}/bin/gptscript-go-tool load --flows-file=blueprint:obot --flow=obotload "ws://${INPUT}" "ws://${OUTPUT}"

--- a/knowledge/tool.gpt
+++ b/knowledge/tool.gpt
@@ -7,6 +7,7 @@ Share Context: context
 Params: Query: A search query that will be evaluated against the knowledge set
 Metadata: category: Capability
 Metadata: icon: https://cdn.jsdelivr.net/npm/@phosphor-icons/core@2/assets/duotone/brain-duotone.svg
+Metadata: noUserAuth: sys.model.provider.credential,knowledge
 
 #!${GPTSCRIPT_TOOL_DIR}/bin/gptscript-go-tool retrieve --flows-file=blueprint:obot "${QUERY}"
 

--- a/ollama-model-provider/tool.gpt
+++ b/ollama-model-provider/tool.gpt
@@ -3,6 +3,7 @@ Description: Model provider for models running on Ollama
 Metadata: envVars: OBOT_OLLAMA_MODEL_PROVIDER_HOST
 Model Provider: true
 Credential: ../model-provider-credential as ollama-model-provider
+Metadata: noUserAuth: ollama-model-provider
 
 #!sys.daemon /usr/bin/env python3 ${GPTSCRIPT_TOOL_DIR}/main.py
 

--- a/openai-model-provider/tool.gpt
+++ b/openai-model-provider/tool.gpt
@@ -3,6 +3,7 @@ Description: Model Provider for OpenAI
 Metadata: envVars: OBOT_OPENAI_MODEL_PROVIDER_API_KEY
 Model Provider: true
 Credential: ../model-provider-credential as openai-model-provider
+Metadata: noUserAuth: openai-model-provider
 
 #!sys.daemon ${GPTSCRIPT_TOOL_DIR}/bin/gptscript-go-tool
 

--- a/vllm-model-provider/tool.gpt
+++ b/vllm-model-provider/tool.gpt
@@ -3,6 +3,7 @@ Description: Model Provider for vLLM
 Metadata: envVars: OBOT_VLLM_MODEL_PROVIDER_ENDPOINT,OBOT_VLLM_MODEL_PROVIDER_API_KEY
 Model Provider: true
 Credential: ../model-provider-credential as vllm-model-provider
+Metadata: noUserAuth: vllm-model-provider
 
 #!sys.daemon ${GPTSCRIPT_TOOL_DIR}/bin/gptscript-go-tool
 

--- a/voyage-model-provider/tool.gpt
+++ b/voyage-model-provider/tool.gpt
@@ -3,6 +3,7 @@ Description: Model provider for Voyage Embeddings
 Metadata: envVars: OBOT_VOYAGE_MODEL_PROVIDER_API_KEY
 Model Provider: true
 Credential: ../model-provider-credential as voyage-model-provider
+Metadata: noUserAuth: voyage-model-provider
 
 #!sys.daemon /usr/bin/env python3 ${GPTSCRIPT_TOOL_DIR}/main.py
 

--- a/website-cleaner/tool.gpt
+++ b/website-cleaner/tool.gpt
@@ -3,5 +3,6 @@ Description: Removes unwanted tags from website HTML, converts it to Markdown an
 Params: Input: input file name (HTML)
 Params: Output: output file name (Markdown)
 Credential: github.com/gptscript-ai/credentials/model-provider
+Metadata: noUserAuth: sys.model.provider.credential
 
 #!${GPTSCRIPT_TOOL_DIR}/bin/gptscript-go-tool

--- a/xai-model-provider/tool.gpt
+++ b/xai-model-provider/tool.gpt
@@ -3,6 +3,7 @@ Description: Model Provider for xAI
 Metadata: envVars: OBOT_XAI_MODEL_PROVIDER_API_KEY
 Model Provider: true
 Credential: ../model-provider-credential as xai-model-provider
+Metadata: noUserAuth: xai-model-provider
 
 #!sys.daemon ${GPTSCRIPT_TOOL_DIR}/bin/gptscript-go-tool
 


### PR DESCRIPTION
The noAuth metadata field indicates to Obot which tools don't need user authentication.

Issue: https://github.com/obot-platform/obot/issues/1256