### PR TITLE
chore: bump anthropic dependency

### DIFF
--- a/anthropic-bedrock-model-provider/requirements.txt
+++ b/anthropic-bedrock-model-provider/requirements.txt
@@ -1,5 +1,5 @@
 boto3
 fastapi
 uvicorn[standard]
-anthropic[bedrock]==0.40.0
+anthropic[bedrock]==0.43.0
 claude3_provider_common @ git+https://github.com/gptscript-ai/claude3-provider-common@2682b94fce767c810254075253ffc6e6900654fc


### PR DESCRIPTION
Bump the anthropic dependency in `anthropic-bedrock-model-provider` to match the version in `anthropic-model-provider`. The version mismatch was breaking Obot's docker build.

