### PR TITLE
enhance: make it easier to run model providers with standalone GPTScript

### DIFF
--- a/anthropic-model-provider/tool.gpt
+++ b/anthropic-model-provider/tool.gpt
@@ -2,7 +2,7 @@ Name: Anthropic
 Description: Model provider for Anthropic hosted Claude3 models
 Metadata: envVars: OBOT_ANTHROPIC_MODEL_PROVIDER_API_KEY
 Model Provider: true
-Credential: ../placeholder-credential as anthropic-model-provider
+Credential: ../placeholder-credential as anthropic-model-provider with OBOT_ANTHROPIC_MODEL_PROVIDER_API_KEY as env_vars
 Metadata: noUserAuth: anthropic-model-provider
 
 #!sys.daemon /usr/bin/env python3 ${GPTSCRIPT_TOOL_DIR}/main.py
@@ -14,6 +14,5 @@ Metadata: noUserAuth: anthropic-model-provider
 ---
 Name: validate
 Description: Validate Anthropic credentials
-Metadata: envVars: OBOT_ANTHROPIC_MODEL_PROVIDER_API_KEY
 
 #!/usr/bin/env python3 ${GPTSCRIPT_TOOL_DIR}/validate.py

--- a/deepseek-model-provider/tool.gpt
+++ b/deepseek-model-provider/tool.gpt
@@ -2,7 +2,7 @@ Name: DeepSeek
 Description: Model Provider for DeepSeek
 Metadata: envVars: OBOT_DEEPSEEK_MODEL_PROVIDER_API_KEY
 Model Provider: true
-Credential: ../placeholder-credential as deepseek-model-provider
+Credential: ../placeholder-credential as deepseek-model-provider with OBOT_DEEPSEEK_MODEL_PROVIDER_API_KEY as env_vars
 Metadata: noUserAuth: deepseek-model-provider
 
 #!sys.daemon ${GPTSCRIPT_TOOL_DIR}/bin/gptscript-go-tool
@@ -14,6 +14,5 @@ Metadata: noUserAuth: deepseek-model-provider
 ---
 Name: validate
 Description: Validate the DeepSeek API key
-Metadata: envVars: OBOT_DEEPSEEK_MODEL_PROVIDER_API_KEY
 
 #!${GPTSCRIPT_TOOL_DIR}/bin/gptscript-go-tool validate

--- a/groq-model-provider/tool.gpt
+++ b/groq-model-provider/tool.gpt
@@ -2,7 +2,7 @@ Name: Groq
 Description: Model provider for models running on Groq
 Metadata: envVars: OBOT_GROQ_MODEL_PROVIDER_API_KEY
 Model Provider: true
-Credential: ../placeholder-credential as groq-model-provider
+Credential: ../placeholder-credential as groq-model-provider with OBOT_GROQ_MODEL_PROVIDER_API_KEY as env_vars
 Metadata: noUserAuth: groq-model-provider
 
 #!sys.daemon ${GPTSCRIPT_TOOL_DIR}/bin/gptscript-go-tool
@@ -14,6 +14,5 @@ https://www.groq.com/logo.svg
 ---
 Name: validate
 Description: Validate the Groq API key
-Metadata: envVars: OBOT_GROQ_MODEL_PROVIDER_API_KEY
 
 #!${GPTSCRIPT_TOOL_DIR}/bin/gptscript-go-tool validate

--- a/ollama-model-provider/tool.gpt
+++ b/ollama-model-provider/tool.gpt
@@ -2,7 +2,7 @@ Name: Ollama
 Description: Model provider for models running on Ollama
 Metadata: envVars: OBOT_OLLAMA_MODEL_PROVIDER_HOST
 Model Provider: true
-Credential: ../placeholder-credential as ollama-model-provider
+Credential: ../placeholder-credential as ollama-model-provider with OBOT_OLLAMA_MODEL_PROVIDER_HOST as env_vars
 Metadata: noUserAuth: ollama-model-provider
 
 #!sys.daemon ${GPTSCRIPT_TOOL_DIR}/bin/gptscript-go-tool
@@ -14,6 +14,5 @@ https://ollama.com/public/ollama.png
 ---
 Name: validate
 Description: Validate the Ollama host connection
-Metadata: envVars: OBOT_OLLAMA_MODEL_PROVIDER_HOST
 
 #!${GPTSCRIPT_TOOL_DIR}/bin/gptscript-go-tool validate

--- a/openai-model-provider/tool.gpt
+++ b/openai-model-provider/tool.gpt
@@ -2,7 +2,7 @@ Name: OpenAI
 Description: Model Provider for OpenAI
 Metadata: envVars: OBOT_OPENAI_MODEL_PROVIDER_API_KEY
 Model Provider: true
-Credential: ../placeholder-credential as openai-model-provider
+Credential: ../placeholder-credential as openai-model-provider with OBOT_OPENAI_MODEL_PROVIDER_API_KEY as env_vars
 Metadata: noUserAuth: openai-model-provider
 
 #!sys.daemon ${GPTSCRIPT_TOOL_DIR}/bin/gptscript-go-tool
@@ -14,6 +14,5 @@ https://cdn.jsdelivr.net/npm/@phosphor-icons/core@2/assets/duotone/open-ai-logo-
 ---
 Name: validate
 Description: Validate the OpenAI API key
-Metadata: envVars: OBOT_OPENAI_MODEL_PROVIDER_API_KEY
 
 #!${GPTSCRIPT_TOOL_DIR}/bin/gptscript-go-tool validate

--- a/placeholder-credential/main.py
+++ b/placeholder-credential/main.py
@@ -1,0 +1,29 @@
+import os
+import json
+import asyncio
+from gptscript import GPTScript, Options
+
+
+if os.getenv("OBOT_RUN_ID") is not None:
+    # This is being run from Obot, and we shouldn't prompt for the credential.
+    # The credential should have been set up outside of this, so just error.
+    print("The credential has not been properly configured")
+    exit(1)
+
+if os.getenv("ENV_VARS") is None:
+    print("No environment variables provided for prompting")
+    exit(1)
+
+
+async def main():
+    g = GPTScript()
+    env_vars = dict()
+
+    for env in os.getenv("ENV_VARS").split(","):
+        out = await g.run("sys.prompt", Options(input=f'{{"message":"Please enter the value for {env}", "env":"{env}", "fields":"{env}","sensitive":"true"}}')).text()
+        env_vars.update(json.loads(out))
+
+    print(json.dumps({"env": env_vars}))
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/placeholder-credential/requirements.txt
+++ b/placeholder-credential/requirements.txt
@@ -1,0 +1,1 @@
+git+https://github.com/gptscript-ai/py-gptscript.git@0cebee3afa51b8c56006e479a990c262bd693ba6#egg=gptscript

--- a/placeholder-credential/tool.gpt
+++ b/placeholder-credential/tool.gpt
@@ -1,7 +1,5 @@
 Name: Placeholder credential
 Description: This is a fake credential tool for the model and auth providers. These credentials are handled in Obot and this tool should never be called.
+Parameters: env_vars: A list of environment variables to prompt for
 
-#!/bin/bash
-
-echo "The credential has not been properly configured"
-exit 1
+#!/usr/bin/env python3 ${GPTSCRIPT_TOOL_DIR}/main.py

--- a/vllm-model-provider/tool.gpt
+++ b/vllm-model-provider/tool.gpt
@@ -2,7 +2,7 @@ Name: vLLM
 Description: Model Provider for vLLM
 Metadata: envVars: OBOT_VLLM_MODEL_PROVIDER_ENDPOINT,OBOT_VLLM_MODEL_PROVIDER_API_KEY
 Model Provider: true
-Credential: ../placeholder-credential as vllm-model-provider
+Credential: ../placeholder-credential as vllm-model-provider with OBOT_VLLM_MODEL_PROVIDER_ENDPOINT,OBOT_VLLM_MODEL_PROVIDER_API_KEY as env_vars
 Metadata: noUserAuth: vllm-model-provider
 
 #!sys.daemon ${GPTSCRIPT_TOOL_DIR}/bin/gptscript-go-tool
@@ -14,6 +14,5 @@ Metadata: noUserAuth: vllm-model-provider
 ---
 Name: validate
 Description: Validate the vLLM configuration
-Metadata: envVars: OBOT_VLLM_MODEL_PROVIDER_ENDPOINT,OBOT_VLLM_MODEL_PROVIDER_API_KEY
 
 #!${GPTSCRIPT_TOOL_DIR}/bin/gptscript-go-tool validate

--- a/voyage-model-provider/tool.gpt
+++ b/voyage-model-provider/tool.gpt
@@ -2,7 +2,7 @@ Name: Voyage
 Description: Model provider for Voyage Embeddings
 Metadata: envVars: OBOT_VOYAGE_MODEL_PROVIDER_API_KEY
 Model Provider: true
-Credential: ../placeholder-credential as voyage-model-provider
+Credential: ../placeholder-credential as voyage-model-provider with OBOT_VOYAGE_MODEL_PROVIDER_API_KEY as env_vars
 Metadata: noUserAuth: voyage-model-provider
 
 #!sys.daemon /usr/bin/env python3 ${GPTSCRIPT_TOOL_DIR}/main.py

--- a/xai-model-provider/tool.gpt
+++ b/xai-model-provider/tool.gpt
@@ -2,7 +2,7 @@ Name: xAI
 Description: Model Provider for xAI
 Metadata: envVars: OBOT_XAI_MODEL_PROVIDER_API_KEY
 Model Provider: true
-Credential: ../placeholder-credential as xai-model-provider
+Credential: ../placeholder-credential as xai-model-provider with OBOT_XAI_MODEL_PROVIDER_API_KEY as env_vars
 Metadata: noUserAuth: xai-model-provider
 
 #!sys.daemon ${GPTSCRIPT_TOOL_DIR}/bin/gptscript-go-tool
@@ -14,6 +14,5 @@ Metadata: noUserAuth: xai-model-provider
 ---
 Name: validate
 Description: Validate the xAI API key
-Metadata: envVars: OBOT_XAI_MODEL_PROVIDER_API_KEY
 
 #!${GPTSCRIPT_TOOL_DIR}/bin/gptscript-go-tool validate


### PR DESCRIPTION
After this change, running standalone GPTScript with one of these model providers will prompt for the proper credential.