### PR TITLE
fix: auth providers: ensure cookie secrets are len 32

### DIFF
--- a/github-auth-provider/main.go
+++ b/github-auth-provider/main.go
@@ -44,6 +44,13 @@ func main() {
 		os.Exit(1)
 	}
 
+	if len(cookieSecret) == 31 {
+		// The cookie secret is supposed to be 32 bytes.
+		// One time we had one come through that was only 31, for an unknown reason.
+		// For now, just pad it with an extra byte to make it 32.
+		cookieSecret = append(cookieSecret, cookieSecret[0])
+	}
+
 	legacyOpts := options.NewLegacyOptions()
 	legacyOpts.LegacyProvider.ProviderType = "github"
 	legacyOpts.LegacyProvider.ProviderName = "github"

--- a/google-auth-provider/main.go
+++ b/google-auth-provider/main.go
@@ -40,6 +40,13 @@ func main() {
 		os.Exit(1)
 	}
 
+	if len(cookieSecret) == 31 {
+		// The cookie secret is supposed to be 32 bytes.
+		// One time we had one come through that was only 31, for an unknown reason.
+		// For now, just pad it with an extra byte to make it 32.
+		cookieSecret = append(cookieSecret, cookieSecret[0])
+	}
+
 	legacyOpts := options.NewLegacyOptions()
 	legacyOpts.LegacyProvider.ProviderType = "google"
 	legacyOpts.LegacyProvider.ProviderName = "google"


### PR DESCRIPTION
I'm still not sure exactly how it happened, but even though we generate 32 bytes for the cookie secret, I one time saw an auth provider crash on launch, saying it was only 31 bytes that it had. This is a little bandaid to prevent that from happening again. I saved the value that caused the problem so that I can investigate it more thoroughly in the future. For now, I just want to prevent it from happening again.