### PR TITLE
chore: unbundle the time tool

### DIFF
--- a/time/tool.gpt
+++ b/time/tool.gpt
@@ -1,7 +1,6 @@
 ---
 Name: Time
 Description: Context tools that expose information about the current time, date, and timezone for the user.
-Metadata: bundle: true
 Share Contexts: Current Date and Time, User Timezone
 
 ---


### PR DESCRIPTION
Having the time tool bundled causes issues with other "utilities." Also, the time tool is just one tool, so we can unbudle it for now.