### PR TITLE
fix: use a semicolon-separated list for provider env vars

### DIFF
--- a/placeholder-credential/main.py
+++ b/placeholder-credential/main.py
@@ -19,7 +19,7 @@ async def main():
     g = GPTScript()
     env_vars = dict()
 
-    for env in os.getenv("ENV_VARS").split(","):
+    for env in os.getenv("ENV_VARS").split(";"):
         out = await g.run("sys.prompt", Options(input=f'{{"message":"Please enter the value for {env}", "env":"{env}", "fields":"{env}","sensitive":"true"}}')).text()
         env_vars.update(json.loads(out))
 

--- a/placeholder-credential/tool.gpt
+++ b/placeholder-credential/tool.gpt
@@ -1,5 +1,5 @@
 Name: Placeholder credential
 Description: This is a fake credential tool for the model and auth providers. These credentials are handled in Obot and this tool should never be called.
-Parameters: env_vars: A list of environment variables to prompt for
+Parameters: env_vars: A semicolon-separated list of environment variables to prompt for
 
 #!/usr/bin/env python3 ${GPTSCRIPT_TOOL_DIR}/main.py

--- a/vllm-model-provider/tool.gpt
+++ b/vllm-model-provider/tool.gpt
@@ -2,7 +2,7 @@ Name: vLLM
 Description: Model Provider for vLLM
 Metadata: envVars: OBOT_VLLM_MODEL_PROVIDER_ENDPOINT,OBOT_VLLM_MODEL_PROVIDER_API_KEY
 Model Provider: true
-Credential: ../placeholder-credential as vllm-model-provider with OBOT_VLLM_MODEL_PROVIDER_ENDPOINT,OBOT_VLLM_MODEL_PROVIDER_API_KEY as env_vars
+Credential: ../placeholder-credential as vllm-model-provider with OBOT_VLLM_MODEL_PROVIDER_ENDPOINT;OBOT_VLLM_MODEL_PROVIDER_API_KEY as env_vars
 Metadata: noUserAuth: vllm-model-provider
 
 #!sys.daemon ${GPTSCRIPT_TOOL_DIR}/bin/gptscript-go-tool


### PR DESCRIPTION
The parsing breaks when using commas; semicolons seemed like the next-best thing.