### PR TITLE
chore: use / for auth provider redirect

### DIFF
--- a/github-auth-provider/main.go
+++ b/github-auth-provider/main.go
@@ -79,8 +79,8 @@ func main() {
 	oauthProxyOpts.Cookie.Name = "obot_access_token"
 	oauthProxyOpts.Cookie.Secret = string(cookieSecret)
 	oauthProxyOpts.Cookie.Secure = strings.HasPrefix(opts.ObotServerURL, "https://")
-	oauthProxyOpts.RawRedirectURL = opts.ObotServerURL + "/oauth2/callback"
 	oauthProxyOpts.Templates.Path = os.Getenv("GPTSCRIPT_TOOL_DIR") + "/../auth-providers-common/templates"
+	oauthProxyOpts.RawRedirectURL = opts.ObotServerURL + "/"
 	if opts.AuthEmailDomains != "" {
 		oauthProxyOpts.EmailDomains = strings.Split(opts.AuthEmailDomains, ",")
 	}

--- a/google-auth-provider/main.go
+++ b/google-auth-provider/main.go
@@ -58,8 +58,8 @@ func main() {
 	oauthProxyOpts.Cookie.Name = "obot_access_token"
 	oauthProxyOpts.Cookie.Secret = string(bytes.TrimSpace(cookieSecret))
 	oauthProxyOpts.Cookie.Secure = strings.HasPrefix(opts.ObotServerURL, "https://")
-	oauthProxyOpts.RawRedirectURL = opts.ObotServerURL + "/oauth2/callback"
 	oauthProxyOpts.Templates.Path = os.Getenv("GPTSCRIPT_TOOL_DIR") + "/../auth-providers-common/templates"
+	oauthProxyOpts.RawRedirectURL = opts.ObotServerURL + "/"
 	if opts.AuthEmailDomains != "" {
 		oauthProxyOpts.EmailDomains = strings.Split(opts.AuthEmailDomains, ",")
 	}


### PR DESCRIPTION
for obot-platform/obot#1488

This should NOT be merged until we are sure that every auth provider's OAuth app is updated to have this as a valid redirect URI.