### PR TITLE
fix: skip empty elements when updating google docs

### DIFF
--- a/google/docs/update_doc.py
+++ b/google/docs/update_doc.py
@@ -1,5 +1,6 @@
 import sys
 import os
+
 import markdown
 from bs4 import BeautifulSoup
 
@@ -13,8 +14,13 @@ def markdown_to_google_doc_requests(markdown_content):
 
     requests = []
     current_index = 1
+
     def add_text_request(text, bold=False, italic=False, underline=False, link=None):
         nonlocal current_index
+        # Skip completely empty or whitespace-only values, except for single newlines
+        if not text.strip() and text != "\n":
+            return
+
         text_style = {
             "bold": bold,
             "italic": italic,
@@ -65,15 +71,12 @@ def markdown_to_google_doc_requests(markdown_content):
             add_text_request("\n")
         elif element.name in ['h1', 'h2', 'h3']:
             add_text_request(element.get_text(), bold=True)
-            add_text_request("\n")
         elif element.name in ['ul']:
             for li in element.find_all('li'):
                 add_text_request("\u2022 " + li.get_text())
-                add_text_request("\n")
         elif element.name in ['ol']:
             for i, li in enumerate(element.find_all('li'), start=1):
                 add_text_request(f"{i}. " + li.get_text())
-                add_text_request("\n")
         elif element.name == 'a':
             add_text_request(element.get_text(), link=element['href'])
         elif element.name == 'table':


### PR DESCRIPTION
Don't add empty text elements when updating Google Docs. This can break doc updates.

Addresses https://github.com/obot-platform/obot/issues/1477

Note: There's a separate issue with styling on updates for ordered and unordered lists that will be addressed in a follow-up.
