### PR TITLE
enhance: create and update google docs by importing markdown directly

### DIFF
--- a/google/docs/move_doc.py
+++ b/google/docs/move_doc.py
@@ -14,13 +14,21 @@ def move_doc(drive_service, document_id, folder_path):
         return
 
     if folder_path.strip() == "/":
+        # Get the current parent folder(s)
+        file_metadata = drive_service.files().get(
+            fileId=document_id,
+            fields="parents"
+        ).execute()
+        current_parents = ",".join(file_metadata.get("parents", []))
+
         # Move the document back to the root folder
         drive_service.files().update(
             fileId=document_id,
-            addParents="root",  # Add to the root folder
-            removeParents="root",  # Ensure no redundant updates
+            addParents="root",
+            removeParents=current_parents,
             fields="id, parents"
         ).execute()
+
         print("Document moved back to the root folder.")
         return
 

--- a/google/docs/read_doc.py
+++ b/google/docs/read_doc.py
@@ -1,5 +1,8 @@
+import io
 import sys
 import os
+
+from googleapiclient.http import MediaIoBaseDownload
 
 from auth import client
 from id import extract_file_id
@@ -11,44 +14,26 @@ def main():
             raise ValueError('DOC_REF environment variable is missing or empty')
 
         file_id = extract_file_id(doc_ref)
-        service = client('docs', 'v1')
-        document = service.documents().get(documentId=file_id).execute()
 
-        print(convert_to_markdown(document))
+        service = client('drive', 'v3')
+
+        request = service.files().export_media(
+            fileId=file_id,
+            mimeType='text/markdown'
+        )
+        file = io.BytesIO()
+        downloader = MediaIoBaseDownload(file, request)
+        done = False
+
+        while not done:
+            _, done = downloader.next_chunk()
+
+        print(file.getvalue().decode('utf-8'))
 
     except Exception as err:
         sys.stderr.write(err)
         sys.exit(1)
 
-def convert_to_markdown(document):
-    md_text = ""
-    for element in document.get('body', {}).get('content', []):
-        if 'paragraph' in element:
-            for part in element['paragraph']['elements']:
-                text_run = part.get('textRun')
-                if text_run:
-                    md_text += text_run['content']
-            md_text += "\n\n"  # Separate paragraphs with extra newlines
-        elif 'table' in element:
-            md_text += parse_table(element['table'])
-            md_text += "\n\n"  # Extra newline after a table
-    return md_text
-
-def parse_table(table):
-    md_table = ""
-    for row in table.get('tableRows', []):
-        row_text = "|"
-        for cell in row.get('tableCells', []):
-            cell_text = ""
-            for content in cell.get('content', []):
-                if 'paragraph' in content:
-                    for element in content['paragraph']['elements']:
-                        text_run = element.get('textRun')
-                        if text_run:
-                            cell_text += text_run['content']
-            row_text += f" {cell_text.strip()} |"
-        md_table += row_text + "\n"
-    return md_table
 
 if __name__ == "__main__":
     main()

--- a/google/docs/requirements.txt
+++ b/google/docs/requirements.txt
@@ -1,5 +1,3 @@
 google-api-python-client
 google-auth-httplib2
 google-auth-oauthlib
-beautifulsoup4
-markdown

--- a/google/docs/tool.gpt
+++ b/google/docs/tool.gpt
@@ -20,7 +20,7 @@ Share Tools: Create Google Doc
 Share Context: Google Docs Context
 Credential: ../credential
 Param: doc_ref: Google Docs ID or share link of the document to read.
-Param: doc_drive_dir: Optional folder path in Google Drive to move the document to after updating it. Use "/" to move the document back to the root folder.
+Param: doc_drive_dir: Optional folder path in Google Drive to move the document to after updating it. Use `/` to move the document back to the root folder.
 Param: doc_content: Markdown formatted content to replace the existing content of the document with.
 
 #!/usr/bin/env python3 ${GPTSCRIPT_TOOL_DIR}/update_doc.py


### PR DESCRIPTION
Instead of parsing google docs to/from markdown:
- import markdown directly via the APIs
- export docs to markdown via the APIs

This makes formatting more consistent and reduces the complexity of both operations considerably.

Addresses https://github.com/obot-platform/obot/issues/1515

Before:

<img width="599" alt="Screenshot 2025-01-29 at 4 22 30 PM" src="https://github.com/user-attachments/assets/4477611e-e868-4a50-a0dd-33043cfcf87d" />

After:

<img width="562" alt="Screenshot 2025-01-29 at 4 22 16 PM" src="https://github.com/user-attachments/assets/39a8d114-e029-40fd-ae21-df8343dd4863" />

