### PR TITLE
fix: formatting for un-ordered lists when updating google docs

### DIFF
--- a/google/docs/update_doc.py
+++ b/google/docs/update_doc.py
@@ -73,12 +73,15 @@ def markdown_to_google_doc_requests(markdown_content):
             add_text_request("\n")
         elif element.name in ['h1', 'h2', 'h3']:
             add_text_request(element.get_text(), bold=True)
+            add_text_request("\n")
         elif element.name in ['ul']:
             for li in element.find_all('li'):
                 add_text_request("\u2022 " + li.get_text())
+                add_text_request("\n")
         elif element.name in ['ol']:
             for i, li in enumerate(element.find_all('li'), start=1):
                 add_text_request(f"{i}. " + li.get_text())
+                add_text_request("\n")
         elif element.name == 'a':
             add_text_request(element.get_text(), link=element['href'])
         elif element.name == 'table':


### PR DESCRIPTION
Addresses https://github.com/obot-platform/obot/issues/1514#issue-2819292148

Before:

<img width="880" alt="Screenshot 2025-01-29 at 3 56 00 PM" src="https://github.com/user-attachments/assets/8a295e5c-36e1-40ec-ac15-1a2ee57d06c5" />

After:

<img width="660" alt="Screenshot 2025-01-29 at 3 55 26 PM" src="https://github.com/user-attachments/assets/f7026236-220e-487d-90d5-576d46ae9aa6" />

