### PR TITLE
enhance: use non-sensitive field for username/email address

### DIFF
--- a/sendgrid/credential/tool.gpt
+++ b/sendgrid/credential/tool.gpt
@@ -1,4 +1,3 @@
-
 Name: SendGrid Credentials
 Description: Credentials for the SendGrid API
 Share Credential: github.com/gptscript-ai/credential as sendgrid.key
@@ -8,4 +7,5 @@ Share Credential: github.com/gptscript-ai/credential as sendgrid.key
 Share Credential: github.com/gptscript-ai/credential as sendgrid.address
     with "Please enter your SendGrid email address" as message and
     address as field and
+    false as sensitive and
     SENDGRID_EMAIL_ADDRESS as env


### PR DESCRIPTION
This change affects the basic auth tool and the SendGrid credential.

Issue: https://github.com/obot-platform/obot/issues/1305