### PR TITLE
chore: add the ability for an Obot release to create a release in tools

### DIFF
--- a/.github/workflows/dispatch.yaml
+++ b/.github/workflows/dispatch.yaml
@@ -1,0 +1,19 @@
+name: Tag Release of tools
+on:
+  repository_dispatch:
+    types: release
+
+jobs:
+  tag-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Create a GitHub release
+        uses: ncipollo/release-action@v1
+        with:
+          skipIfReleaseExists: true
+          tag: ${{ github.event.client_payload.tag }}
+          commit: main
+          name: Release ${{ github.event.client_payload.tag }}
+          generateReleaseNotes: true
+          prerelease: ${{ contains(github.event.client_payload.tag, '-rc') }}


### PR DESCRIPTION
If the corresponding release for Obot already exists, then this won't update or delete it.