### PR TITLE
fix: remove oauth metadata from google search tool

### DIFF
--- a/google/search/tool.gpt
+++ b/google/search/tool.gpt
@@ -28,7 +28,3 @@ Google Search
 ---
 !metadata:*:icon
 /admin/assets/google_icon_small.png
-
----
-!metadata:*:oauth
-google


### PR DESCRIPTION
The `Google Search` tool makes unauthenticated requests to google
search with a headless browser. Remove the OAuth metadata from the
tool so it can be used without setting up Google OAuth for tools.

Addresses https://github.com/obot-platform/obot/issues/1548

