### PR TITLE
fix: modify Jira tool for API key support

### DIFF
--- a/atlassian/credential/tool.gpt
+++ b/atlassian/credential/tool.gpt
@@ -2,7 +2,8 @@ Name: Atlassian OAuth Credential
 Share Credential: ../../oauth2 as atlassian
     with ATLASSIAN_OAUTH_TOKEN as token and
         atlassian as integration and
-        ATLASSIAN_OAUTH_TOKEN as prompt_tokens and
+        ATLASSIAN_API_TOKEN as prompt_tokens and
+        ATLASSIAN_EMAIL;ATLASSIAN_SITE_URL as prompt_vars and
         "offline_access
         read:me
         read:account

--- a/atlassian/jira/tool.gpt
+++ b/atlassian/jira/tool.gpt
@@ -174,6 +174,7 @@ If you don't know what Jira Sites are available for the current user, call the L
 to get the list of sites that the user has access to.
 Tools that require a site_id must be called with a site_id from the Jira Sites that are available for the current user.
 When it's unclear which Jira Site a user is referring to, always ask the user to select a site before calling a tool that requires a site_id argument.
+When using the Jira Sites tool, it may tell you that you don't need a site_id. If it does, then that's great and you can move along without it.
 When information about the current user is needed to fulfill a request, call the Get Current User tool for the applicable Jira Sites.
 Always call Get Project to gather more information about a Project when prompted to interact with the issues in a project.
 Issue descriptions are always in ADF (Atlassian Document Format) and must be passed as a JSON string when calling the Create Issue tool.


### PR DESCRIPTION
The Jira API is different for OAuth versus API keys. This change modifies the Jira tool so that it works with API keys and OAuth.

Issue: https://github.com/obot-platform/obot/issues/1555