### PR TITLE
fix: return correct column names from dedicated table rows tool

### DIFF
--- a/database/pkg/cmd/rows.go
+++ b/database/pkg/cmd/rows.go
@@ -23,7 +23,7 @@ func ListDatabaseTableRows(ctx context.Context, dbFile *os.File, table string) (
 	query := fmt.Sprintf("SELECT * FROM %q;", table)
 
 	// Execute the query using RunDatabaseCommand
-	rawOutput, err := RunDatabaseCommand(ctx, dbFile, fmt.Sprintf("%q", query))
+	rawOutput, err := RunDatabaseCommand(ctx, dbFile, fmt.Sprintf("-header %q", query))
 	if err != nil {
 		return "", fmt.Errorf("error executing query for table %q: %w", table, err)
 	}


### PR DESCRIPTION
Addresses https://github.com/obot-platform/obot/issues/1629

JSON response from tool after change:

```json
{
    "columns": [
        "name",
        "difficulty"
    ],
    "rows": [
        {
            "difficulty": "Easy",
            "name": "Python"
        },
        {
            "difficulty": "Medium",
            "name": "JavaScript"
        },
        {
            "difficulty": "Medium",
            "name": "Java"
        },
        {
            "difficulty": "Hard",
            "name": "C++"
        },
        {
            "difficulty": "Medium",
            "name": "Ruby"
        },
        {
            "difficulty": "Medium",
            "name": "Swift"
        }
    ]
}
```

and the Obot UI:

<img width="339" alt="Screenshot 2025-02-03 at 7 25 32 PM" src="https://github.com/user-attachments/assets/6cb52153-0b5a-49c9-89d8-0760a00b0588" />

