### PR TITLE
fix: convert slack message datetimes to user tz in code

### DIFF
--- a/slack/src/tools.js
+++ b/slack/src/tools.js
@@ -8,7 +8,6 @@ export async function userContext(webClient) {
     console.log(`Real Name: ${userResult.user.profile.real_name}`)
     console.log(`Display Name: ${userResult.user.profile.display_name}`)
     console.log(`User ID: ${result.user_id}`)
-    console.log(`Default time zone: ${userResult.user.tz_label} (UTC offset ${userResult.user.tz_offset / 3600} hours)`)
 }
 
 export async function listChannels(webClient) {
@@ -403,6 +402,20 @@ function userToString(user) {
     return str
 }
 
+const userTimezone = (() => {
+    const envTz = (process.env.OBOT_USER_TIMEZONE ?? 'UTC').trim();
+
+    // Verify the time zone or default to UTC
+    let timeZone = envTz;
+    try {
+        new Intl.DateTimeFormat(undefined, { timeZone }).format();
+    } catch {
+        timeZone = 'UTC';
+    }
+
+    return timeZone;
+})()
+
 async function messageToString(webClient, message) {
     const time = new Date(parseFloat(message.ts) * 1000)
     let userName = message.user
@@ -420,7 +433,8 @@ async function messageToString(webClient, message) {
         } catch (e) {}
     }
 
-    let str = `${time.toLocaleString()}: ${userName}: ${message.text}\n`
+
+    let str = `${time.toLocaleString('en-US', { timeZone: userTimezone, timeZoneName: 'short' })}: ${userName}: ${message.text}\n`
     str += `  message ID: ${message.ts}\n`
     if (message.blocks && message.blocks.length > 0) {
         str += `  message blocks: ${JSON.stringify(message.blocks)}\n`

--- a/slack/tool.gpt
+++ b/slack/tool.gpt
@@ -175,7 +175,7 @@ Param: limit: the number of messages to return
 
 ---
 Name: User Context
-Description: Get information about the logged in user and default time zone.
+Description: Get information about the logged in user.
 Credential: ./credential
 
 #!/usr/bin/env node ${GPTSCRIPT_TOOL_DIR}/index.js userContext

--- a/slack/tool.gpt
+++ b/slack/tool.gpt
@@ -198,9 +198,27 @@ When mentioning a user in a message you create, use the format <@USERID>, includ
 The user ID can be obtained from the List Users or Search Users tool.
 
 Do not provide channel, thread, or message IDs in the output, as these are not helpful for the user.
-When you use the search_messages tool, you can use normal Slack search filters. If you filter by user, use the full username, which can be obtained from the list_users or search_users tools.
+When you use the search-messages tool, you can use normal Slack search filters. If you filter by user, use the full username, which can be obtained from the search-users or list-users tools.
 
 Display all dates and times in the user's preferred timezone. When the user gives values for dates and times, assume they are in the user's preferred timezone unless otherwise specified by the user.
+
+Use the following guidelines when constructing `query` arguments for the search-messages tool:
+- `*` (Wildcard): Matches any number of characters in a term. Example: `dev*` matches "developer", "development", etc.
+- `-` (Negation): Excludes a term or modifier by prepending a dash. Example: `-in:#random` excludes results from `#random`, `-update` excludes messages containing "update".
+- Boolean Operators: Use `AND`, `OR`, and `NOT` to refine searches.
+  Examples:
+  - `project AND update` finds messages containing both "project" and "update".
+  - `project OR update` finds messages containing either "project" or "update".
+  - `project NOT update` finds messages containing "project" but excluding "update".
+- Combining multiple modifiers: Separate each modifier and search term with spaces (order does not matter). Example: `update from:@alice in:#general after:2025-01-01 -in:#random`
+
+The following search modifiers can be used in search-messages `query` arguments:
+- `after:<date>`: Matches messages sent after the specified date (exclusive, so excludes messages from the given date). Must be in `YYYY-MM-DD` format (no time/timezone). Example: `after:2025-01-01`
+- `before:<date>`: Matches messages sent before the specified date (exclusive, so excludes messages from the given date). Example: `before:2025-01-01`
+- `with:<user>`: Matches messages from threads/DMs that include the specified user. Example: `with:@bob`
+- `from:<user>`: Matches messages sent by the specified user. Example: `from:@alice`
+- `in:<channel>`: Matches messages from the specified channel. Example: `in:#general`
+- `is:<type>`: Matches messages of the specified type. Valid types are `dm`, `thread`. Example: `is:thread`
 
 ## End of instructions for using Slack tools
 


### PR DESCRIPTION
- Convert slack message datetimes to user tz in code
- Improve slack search messages context

Addresses https://github.com/obot-platform/obot/issues/584 again.