### PR TITLE
Tool index refactoring

### DIFF
--- a/anthropic-model-provider/tool.gpt
+++ b/anthropic-model-provider/tool.gpt
@@ -4,6 +4,7 @@ Model Provider: true
 Credential: ../placeholder-credential as anthropic-model-provider with OBOT_ANTHROPIC_MODEL_PROVIDER_API_KEY as env_vars
 Metadata: noUserAuth: anthropic-model-provider
 
+
 #!sys.daemon /usr/bin/env python3 ${GPTSCRIPT_TOOL_DIR}/main.py
 
 ---

--- a/atlassian/jira/tool.gpt
+++ b/atlassian/jira/tool.gpt
@@ -1,7 +1,6 @@
 ---
 Name: Jira
 Description: Tools for interacting with Jira
-Metadata: bundle: true
 Share Tools: List Jira Sites, List Projects, Get Project, List Users, Get User, Get Current User, Search Issues, List Issues, Get Issue, Create Issue, Edit Issue, Add Comment, List Comments
 
 ---
@@ -181,10 +180,6 @@ Issue descriptions are always in ADF (Atlassian Document Format) and must be pas
 The List Issues tool can be used to search for issues in a Jira instance. The jql_query argument provided to this tool must be valid JQL (Jira Query Language) query.
 
 # END INSTRUCTIONS: Jira Tools
-
----
-!metadata:*:category
-Jira
 
 ---
 !metadata:*:icon

--- a/atlassian/jira/tool.gpt
+++ b/atlassian/jira/tool.gpt
@@ -1,6 +1,7 @@
 ---
 Name: Jira
 Description: Tools for interacting with Jira
+Metadata: bundle: true
 Share Tools: List Jira Sites, List Projects, Get Project, List Users, Get User, Get Current User, Search Issues, List Issues, Get Issue, Create Issue, Edit Issue, Add Comment, List Comments
 
 ---

--- a/bluesky/tool.gpt
+++ b/bluesky/tool.gpt
@@ -1,6 +1,7 @@
 ---
 Name: Bluesky
 Description: Tools for interacting with Bluesky (bsky.app)
+Metadata: bundle: true
 Share Tools: Create Post, Delete Post, Search Posts, Search Users
 
 ---

--- a/bluesky/tool.gpt
+++ b/bluesky/tool.gpt
@@ -1,6 +1,5 @@
 ---
 Name: Bluesky
-Metadata: bundle: true
 Description: Tools for interacting with Bluesky (bsky.app)
 Share Tools: Create Post, Delete Post, Search Posts, Search Users
 
@@ -50,10 +49,6 @@ Share Context: Current Date and Time from ../time
 Param: post_uri: The URI of the post to delete.
 
 #!/usr/bin/env npm --silent --prefix ${GPTSCRIPT_TOOL_DIR} run tool -- deletePost
-
----
-!metadata:*:category
-Bluesky
 
 ---
 !metadata:*:icon

--- a/browser/tool.gpt
+++ b/browser/tool.gpt
@@ -1,5 +1,6 @@
 Name: Browser
 Description: Tools to navigate websites using a browser.
+Metadata: bundle: true
 Credentials: github.com/gptscript-ai/credentials/model-provider
 Share Tools: Browse, Get Page Contents, Filter, Fill, Enter, Scroll, Back, Forward, Screenshot, Download File From URL
 Metadata: noUserAuth: sys.model.provider.credential

--- a/browser/tool.gpt
+++ b/browser/tool.gpt
@@ -1,6 +1,5 @@
 Name: Browser
 Description: Tools to navigate websites using a browser.
-Metadata: bundle: true
 Credentials: github.com/gptscript-ai/credentials/model-provider
 Share Tools: Browse, Get Page Contents, Filter, Fill, Enter, Scroll, Back, Forward, Screenshot, Download File From URL
 Metadata: noUserAuth: sys.model.provider.credential
@@ -184,10 +183,6 @@ Name: service
 Metadata: index: false
 
 #!sys.daemon /usr/bin/env npm --prefix ${GPTSCRIPT_TOOL_DIR} run server
-
----
-!metadata:*:category
-Browser
 
 ---
 !metadata:*:icon

--- a/excel/tool.gpt
+++ b/excel/tool.gpt
@@ -1,6 +1,7 @@
 ---
 Name: Excel
 Description: Tools for interacting with Microsoft Excel workbooks.
+Metadata: bundle: true
 Share Tools: List Workbooks, List Worksheets, Get Worksheet Column Headers, Get Worksheet Data, Get Worksheet Tables, Query Worksheet Data, Add Worksheet Row, Add Worksheet Column, Create Worksheet, Get Dates From Serials
 
 ---

--- a/excel/tool.gpt
+++ b/excel/tool.gpt
@@ -140,14 +140,6 @@ If the user asks for a calculation or a formula, use an excel formula if possibl
 ## End of instructions for using Excel tools
 
 ---
-!metadata:Excel:bundle
-true
-
----
-!metadata:*:category
-Excel
-
----
 !metadata:*:icon
 /admin/assets/excel_icon_small.svg
 

--- a/file-summarizer/tool.gpt
+++ b/file-summarizer/tool.gpt
@@ -6,7 +6,6 @@ Params: output_file: (Optional) Name of the file to save the summary, default to
 
 #!/usr/bin/env python3 ${GPTSCRIPT_TOOL_DIR}/summarize.py
 
-
 ---
 !metadata:*:category
 Utilities

--- a/github/tool.gpt
+++ b/github/tool.gpt
@@ -1,7 +1,6 @@
 ---
 Name: GitHub
 Description: Tools for interacting with GitHub
-Metadata: bundle: true
 Share Tools: Search Issues and PRs, Get Issue, Create Issue, Modify Issue, Close Issue, List Issue Comments, Add Comment to Issue, Get PR, Create PR, Modify PR, Close PR, List PR Comments, Add Comment to PR, List Repos, Get Star Count, List Assigned Issues, List PRs for Review, Add Issue Labels, Remove Issue Labels
 
 ---
@@ -252,10 +251,6 @@ If you are unable to access resources because of a permissions issue, inform the
 Refer them to this link for more information on how the OAuth permissions work in GitHub - https://docs.github.com/en/organizations/managing-oauth-access-to-your-organizations-data/about-oauth-app-access-restrictions.
 
 ## End of instructions for using GitHub tools
-
----
-!metadata:*:category
-GitHub
 
 ---
 !metadata:*:icon

--- a/github/tool.gpt
+++ b/github/tool.gpt
@@ -1,6 +1,7 @@
 ---
 Name: GitHub
 Description: Tools for interacting with GitHub
+Metadata: bundle: true
 Share Tools: Search Issues and PRs, Get Issue, Create Issue, Modify Issue, Close Issue, List Issue Comments, Add Comment to Issue, Get PR, Create PR, Modify PR, Close PR, List PR Comments, Add Comment to PR, List Repos, Get Star Count, List Assigned Issues, List PRs for Review, Add Issue Labels, Remove Issue Labels
 
 ---

--- a/gitlab/tool.gpt
+++ b/gitlab/tool.gpt
@@ -1,6 +1,5 @@
 ---
 Name: GitLab
-Metadata: bundle: true
 Description: Tools for interacting with GitLab.
 Share Tools: Search Issues, List Project Issues, List My Assigned Issues, List My Created Issues, Get Issue Details, Create Issue, Update Issue, Delete Issue, Add Issue Comment, Search Merge Requests, List Project Merge Requests, List My Assigned Merge Requests, List My Opened Merge Requests, Get Merge Request Details, Create Merge Request, Update Merge Request, Delete Merge Request, Add Merge Request Comment, Approve Merge Request, Lookup User ID
 
@@ -240,10 +239,6 @@ If the namespace is not specified, assume the namespace should be the current us
 
 
 ## End of instructions for using the GitLab tools
-
----
-!metadata:*:category
-GitLab
 
 ---
 !metadata:*:icon

--- a/gitlab/tool.gpt
+++ b/gitlab/tool.gpt
@@ -1,6 +1,7 @@
 ---
 Name: GitLab
 Description: Tools for interacting with GitLab.
+Metadata: bundle: true
 Share Tools: Search Issues, List Project Issues, List My Assigned Issues, List My Created Issues, Get Issue Details, Create Issue, Update Issue, Delete Issue, Add Issue Comment, Search Merge Requests, List Project Merge Requests, List My Assigned Merge Requests, List My Opened Merge Requests, Get Merge Request Details, Create Merge Request, Update Merge Request, Delete Merge Request, Add Merge Request Comment, Approve Merge Request, Lookup User ID
 
 ---

--- a/google/docs/tool.gpt
+++ b/google/docs/tool.gpt
@@ -1,6 +1,5 @@
 ---
 Name: Google Docs
-Metadata: bundle: true
 Description: Tools for managing Google Docs
 Share Tools: Read Google Doc, Create Google Doc, Update Google Doc
 
@@ -54,10 +53,6 @@ When calling the `Update Google Doc` tool, you must provide the entire modified 
 For the `drive_dir` parameter, you can optionally specify folder paths directly, such as `Haikus` or `Haikus/New`, to move the document to a specific folder in Google Drive. If you do not provide a `drive_dir`, the new documents will be created in the root Google Drive folder, and updated documents will remain in their current folder.
 
 ## End of instructions for using Google Docs tools
-
----
-!metadata:*:category
-Google Docs
 
 ---
 !metadata:*:icon

--- a/google/docs/tool.gpt
+++ b/google/docs/tool.gpt
@@ -1,6 +1,7 @@
 ---
 Name: Google Docs
 Description: Tools for managing Google Docs
+Metadata: bundle: true
 Share Tools: Read Google Doc, Create Google Doc, Update Google Doc
 
 ---

--- a/google/gmail/tool.gpt
+++ b/google/gmail/tool.gpt
@@ -1,6 +1,7 @@
 ---
 Name: Gmail
 Description: Tools for interacting with a user's Gmail account
+Metadata: bundle: true
 Share Tools: List Inbox, Read Email, Search Emails, Send Email, Delete Email, List Drafts, Create Draft, Update Draft, Delete Draft, Send Draft
 
 ---

--- a/google/gmail/tool.gpt
+++ b/google/gmail/tool.gpt
@@ -1,6 +1,5 @@
 ---
 Name: Gmail
-Metadata: bundle: true
 Description: Tools for interacting with a user's Gmail account
 Share Tools: List Inbox, Read Email, Search Emails, Send Email, Delete Email, List Drafts, Create Draft, Update Draft, Delete Draft, Send Draft
 
@@ -149,10 +148,6 @@ These email IDs are not useful to the user, so don't show them to the user.
 Instead, get the contents of the elements and display that to the user.
 
 ## End of instructions for getting emails from a dataset
-
----
-!metadata:*:category
-Gmail
 
 ---
 !metadata:*:icon

--- a/google/search/tool.gpt
+++ b/google/search/tool.gpt
@@ -1,6 +1,7 @@
 ---
 Name: Google Search
 Description: Tools for using Google Search
+Metadata: bundle: true
 Share Tools: Search
 
 ---

--- a/google/search/tool.gpt
+++ b/google/search/tool.gpt
@@ -1,6 +1,5 @@
 ---
 Name: Google Search
-Metadata: bundle: true
 Description: Tools for using Google Search
 Share Tools: Search
 
@@ -20,10 +19,6 @@ Name: service
 Metadata: index: false
 
 #!sys.daemon /usr/bin/env npm --prefix ${GPTSCRIPT_TOOL_DIR} run server
-
----
-!metadata:*:category
-Google Search
 
 ---
 !metadata:*:icon

--- a/google/sheets/tool.gpt
+++ b/google/sheets/tool.gpt
@@ -1,6 +1,5 @@
 ---
 Name: Google Sheets
-Metadata: bundle: true
 Description: Tools for accessing, creating, and modifying Google Sheets
 Share Tools: Read Spreadsheet, Query Spreadsheet, Read Tables From Spreadsheet, Create Spreadsheet, Append Cells To Spreadsheet, Update Cell In Spreadsheet
 
@@ -89,10 +88,6 @@ Write the query such that it returns the minimum number of columns and rows nece
 Do your best to always return the complete data that the user asked for, even if it is a large dataset.
 
 ## End of instructions for using Google Sheets tools
-
----
-!metadata:*:category
-Google Sheets
 
 ---
 !metadata:*:icon

--- a/google/sheets/tool.gpt
+++ b/google/sheets/tool.gpt
@@ -1,6 +1,7 @@
 ---
 Name: Google Sheets
 Description: Tools for accessing, creating, and modifying Google Sheets
+Metadata: bundle: true
 Share Tools: Read Spreadsheet, Query Spreadsheet, Read Tables From Spreadsheet, Create Spreadsheet, Append Cells To Spreadsheet, Update Cell In Spreadsheet
 
 ---

--- a/google/youtube/tool.gpt
+++ b/google/youtube/tool.gpt
@@ -1,6 +1,5 @@
 ---
 Name: YouTube
-Metadata: bundle: true
 Description: Tools for interacting with YouTube
 Share Tools: Transcribe YouTube Video
 
@@ -14,10 +13,6 @@ Param: model: (Optional) The name of the model to use when cleaning up and summa
 Metadata: noUserAuth: sys.model.provider.credential
 
 #!/usr/bin/env python3 ${GPTSCRIPT_TOOL_DIR}/transcriber.py
-
----
-!metadata:*:category
-YouTube
 
 ---
 !metadata:*:icon

--- a/google/youtube/tool.gpt
+++ b/google/youtube/tool.gpt
@@ -1,6 +1,7 @@
 ---
 Name: YouTube
 Description: Tools for interacting with YouTube
+Metadata: bundle: true
 Share Tools: Transcribe YouTube Video
 
 ---

--- a/images/tool.gpt
+++ b/images/tool.gpt
@@ -1,6 +1,5 @@
 ---
 Name: Images
-Metadata: bundle: true
 Description: Tools for analyzing and generating images
 Share Tools: Analyze Images, Generate Images
 
@@ -60,10 +59,6 @@ e.g. Analyzing a single image: ["https://example.com/image2.png"]
 e.g. Analyzing multiple images: ["https://example.com/image1.webp", "cool.jpg", "cow.webp", "generated_image_defg1234.png", "https://example.com/image2.png"]
 
 # END INSTRUCTIONS: Analyze Images tool
-
----
-!metadata:*:category
-Images
 
 ---
 !metadata:*:icon

--- a/images/tool.gpt
+++ b/images/tool.gpt
@@ -1,6 +1,7 @@
 ---
 Name: Images
 Description: Tools for analyzing and generating images
+Metadata: bundle: true
 Share Tools: Analyze Images, Generate Images
 
 ---

--- a/index.yaml
+++ b/index.yaml
@@ -1,68 +1,49 @@
 tools:
   sendgrid:
     reference: ./sendgrid
-    all: true
   file-summarizer:
     reference: ./file-summarizer
-    all: true
   database:
     reference: ./database
   zoom:
     reference: ./zoom
-    all: true
   atlassian-jira:
     reference: ./atlassian/jira
-    all: true
   wordpress:
     reference: ./wordpress
-    all: true
   excel:
     reference: ./excel
-    all: true
   browser:
     reference: ./browser
-    all: true
   bluesky:
     reference: ./bluesky
-    all: true
   slack:
     reference: ./slack
-    all: true
   linkedin-publishing:
     reference: ./linkedin-publishing
-    all: true
   notion:
     reference: ./notion
-    all: true
   google-docs:
     reference: ./google/docs
-    all: true
   google-gmail:
     reference: ./google/gmail
-    all: true
   google-search:
     reference: ./google/search
-    all: true
   google-sheets:
     reference: ./google/sheets
-    all: true
   gitlab:
     reference: ./gitlab
-    all: true
   images:
     reference: ./images
-    all: true
   outlook-mail:
     reference: ./outlook/mail
-    all: true
   outlook-calender:
     reference: ./outlook/calendar
-    all: true
   github:
     reference: ./github
-    all: true
   time:
     reference: ./time
+    nameOverride: time
   workspace-files:
     reference: ./workspace-files
   tasks:

--- a/index.yaml
+++ b/index.yaml
@@ -43,7 +43,6 @@ tools:
     reference: ./github
   time:
     reference: ./time
-    nameOverride: time
   workspace-files:
     reference: ./workspace-files
   tasks:
@@ -54,7 +53,6 @@ tools:
     reference: ./shell
   word:
     reference: ./word
-    all: true
 
 knowledgeDataSources:
   notion-data-source:

--- a/linkedin-publishing/tool.gpt
+++ b/linkedin-publishing/tool.gpt
@@ -1,7 +1,6 @@
 ---
 Name: LinkedIn Publishing
 Description: Tools for publishing content to LinkedIn with the LinkedIn APIs
-Metadata: bundle: true
 Share Tools: Get Current LinkedIn User, Create LinkedIn Post
 
 ---
@@ -40,10 +39,6 @@ Share Context: ../time
 You have tools to help with publishing content to LinkedIn with the LinkedIn API.
 
 # End of instructions for using LinkedIn Publishing tools
-
----
-!metadata:*:category
-LinkedIn
 
 ---
 !metadata:*:icon

--- a/linkedin-publishing/tool.gpt
+++ b/linkedin-publishing/tool.gpt
@@ -1,6 +1,7 @@
 ---
 Name: LinkedIn Publishing
 Description: Tools for publishing content to LinkedIn with the LinkedIn APIs
+Metadata: bundle: true
 Share Tools: Get Current LinkedIn User, Create LinkedIn Post
 
 ---

--- a/notion/tool.gpt
+++ b/notion/tool.gpt
@@ -1,6 +1,7 @@
 ---
 Name: Notion
 Description: Tools for interacting with Notion
+Metadata: bundle: true
 Share Tools: Get Page, Get Database, Search, Create Page, List Users, Get Database Properties, Add Database Row, Update Database Row, Update Page
 
 ---

--- a/notion/tool.gpt
+++ b/notion/tool.gpt
@@ -1,7 +1,6 @@
 ---
 Name: Notion
 Description: Tools for interacting with Notion
-Metadata: bundle: true
 Share Tools: Get Page, Get Database, Search, Create Page, List Users, Get Database Properties, Add Database Row, Update Database Row, Update Page
 
 ---
@@ -109,10 +108,6 @@ You cannot use the Create Page tool to update the contents of a page. It is only
 Every time you are about to create a new page and the user isn't explicitly asking for one, ask them to confirm before proceeding.
 
 ## End of instructions for using Notion tools
-
----
-!metadata:*:category
-Notion
 
 ---
 !metadata:*:icon

--- a/outlook/calendar/tool.gpt
+++ b/outlook/calendar/tool.gpt
@@ -1,6 +1,7 @@
 ---
 Name: Outlook Calendar
 Description: Tools for interacting with Microsoft Outlook Calendar.
+Metadata: bundle: true
 Share Tools: List Calendars, List Events Today, List Events, Get Event Details, Create Event, Invite User To Event, Delete Event, Search Events, Respond To Event
 
 ---

--- a/outlook/calendar/tool.gpt
+++ b/outlook/calendar/tool.gpt
@@ -1,6 +1,5 @@
 ---
 Name: Outlook Calendar
-Metadata: bundle: true
 Description: Tools for interacting with Microsoft Outlook Calendar.
 Share Tools: List Calendars, List Events Today, List Events, Get Event Details, Create Event, Invite User To Event, Delete Event, Search Events, Respond To Event
 
@@ -195,10 +194,6 @@ In most circumstances, this event will not span multiple days. Ask for confirmat
 event that spans multiple days.
 
 ## End of instructions for scheduling recurring meetings in Outlook Calendar
-
----
-!metadata:*:category
-Outlook Calendar
 
 ---
 !metadata:*:icon

--- a/outlook/mail/tool.gpt
+++ b/outlook/mail/tool.gpt
@@ -1,6 +1,7 @@
 ---
 Name: Outlook Mail
 Description: Tools for interacting with Microsoft Outlook Mail.
+Metadata: bundle: true
 Share Tools: List Mail Folders, List Messages, Get Message Details, Search Messages, Create Draft, Send Draft, Delete Message, Move Message
 
 ---

--- a/outlook/mail/tool.gpt
+++ b/outlook/mail/tool.gpt
@@ -1,7 +1,6 @@
 ---
 Name: Outlook Mail
 Description: Tools for interacting with Microsoft Outlook Mail.
-Metadata: bundle: true
 Share Tools: List Mail Folders, List Messages, Get Message Details, Search Messages, Create Draft, Send Draft, Delete Message, Move Message
 
 ---
@@ -126,10 +125,6 @@ When creating a draft message, ensure the body is valid markdown and there are n
 Do not attempt to forward emails. Email forwarding is not supported.
 
 ## End of instructions for using the Microsoft Outlook Mail tools
-
----
-!metadata:*:category
-Outlook Mail
 
 ---
 !metadata:*:icon

--- a/sendgrid/tool.gpt
+++ b/sendgrid/tool.gpt
@@ -1,6 +1,7 @@
 ---
 Name: SendGrid
 Description: Tools for interacting with SendGrid.
+Metadata: bundle: true
 Share Tools: Send Email
 
 ---

--- a/sendgrid/tool.gpt
+++ b/sendgrid/tool.gpt
@@ -1,6 +1,5 @@
 ---
 Name: SendGrid
-Metadata: bundle: true
 Description: Tools for interacting with SendGrid.
 Share Tools: Send Email
 
@@ -34,10 +33,6 @@ When calling the Send Email tool:
 - Before sending every email, check the body for placeholder or template text and, when found, prompt the user to resolve them. Afterwards, send the email using the resolved values in the body
 
 # END INSTRUCTIONS: Send Email tool
-
----
-!metadata:*:category
-SendGrid
 
 ---
 !metadata:*:icon

--- a/slack/tool.gpt
+++ b/slack/tool.gpt
@@ -1,7 +1,6 @@
 ---
 Name: Slack
 Description: Tools for interacting with Slack
-Metadata: bundle: true
 Share Tools: List Channels, Search Channels, Get Channel History, Get Channel History by Time, Get Thread History, Search Messages, Send Message, Send Message in Thread, List Users, Search Users, Send DM, Send DM in Thread, Get Message Link, Get DM History, Get DM Thread History
 
 ---
@@ -221,10 +220,6 @@ The following search modifiers can be used in search-messages `query` arguments:
 - `is:<type>`: Matches messages of the specified type. Valid types are `dm`, `thread`. Example: `is:thread`
 
 ## End of instructions for using Slack tools
-
----
-!metadata:*:category
-Slack
 
 ---
 !metadata:*:icon

--- a/slack/tool.gpt
+++ b/slack/tool.gpt
@@ -1,6 +1,7 @@
 ---
 Name: Slack
 Description: Tools for interacting with Slack
+Metadata: bundle: true
 Share Tools: List Channels, Search Channels, Get Channel History, Get Channel History by Time, Get Thread History, Search Messages, Send Message, Send Message in Thread, List Users, Search Users, Send DM, Send DM in Thread, Get Message Link, Get DM History, Get DM Thread History
 
 ---

--- a/word/tool.gpt
+++ b/word/tool.gpt
@@ -47,10 +47,6 @@ Microsoft Word document names are not considered document IDs.
 ## End of instructions for using Microsoft Word tools
 
 ---
-!metadata:*:category
-Word
-
----
 !metadata:*:icon
 https://cdn.jsdelivr.net/npm/@phosphor-icons/core@2/assets/duotone/microsoft-word-logo-duotone.svg
 

--- a/wordpress/tool.gpt
+++ b/wordpress/tool.gpt
@@ -1,6 +1,7 @@
 ---
 Name: Wordpress
 Description: Tools for interacting with self-hosted and hosted Wordpress sites that support basic auth. Wordpress.com sites are not supported.
+Metadata: bundle: true
 Share Tools: List Users, Get User, List Posts, Retrieve Post, Create Post, Update Post, Delete Post, Get Site Settings
 
 ---

--- a/wordpress/tool.gpt
+++ b/wordpress/tool.gpt
@@ -1,7 +1,6 @@
 ---
 Name: Wordpress
 Description: Tools for interacting with self-hosted and hosted Wordpress sites that support basic auth. Wordpress.com sites are not supported.
-Metadata: bundle: true
 Share Tools: List Users, Get User, List Posts, Retrieve Post, Create Post, Update Post, Delete Post, Get Site Settings
 
 ---
@@ -136,10 +135,6 @@ WordPress posts support the following formats:
 - chat: A chat transcript.
 
 ## End of instructions for using Wordpress tools
-
----
-!metadata:*:category
-WordPress
 
 ---
 !metadata:*:icon

--- a/zoom/tool.gpt
+++ b/zoom/tool.gpt
@@ -1,7 +1,6 @@
 ---
 Name: Zoom
 Description: Tools for interacting with Zoom
-Metadata: bundle: true
 Share Tools: Get User, Create Meeting, Update Meeting, List Meeting Templates, Get Meeting, Delete Meeting, List Meetings, List Upcoming Meetings, Get Meeting Invitation, Get Meeting Recordings, List User Recordings, Get Meeting Summary, Get Past Meeting Details, List Available Timezones
 
 ---
@@ -170,10 +169,6 @@ Share Context: ../time
 You can use this tool to interact with Zoom with Zoom APIs.
 
 # End of instructions for using Zoom tools
-
----
-!metadata:*:category
-Zoom
 
 ---
 !metadata:*:icon

--- a/zoom/tool.gpt
+++ b/zoom/tool.gpt
@@ -1,6 +1,7 @@
 ---
 Name: Zoom
 Description: Tools for interacting with Zoom
+Metadata: bundle: true
 Share Tools: Get User, Create Meeting, Update Meeting, List Meeting Templates, Get Meeting, Delete Meeting, List Meetings, List Upcoming Meetings, Get Meeting Invitation, Get Meeting Recordings, List User Recordings, Get Meeting Summary, Get Past Meeting Details, List Available Timezones
 
 ---


### PR DESCRIPTION
This pr removes category and `all: true` per https://github.com/obot-platform/obot/issues/1026.

The import logic will be changed in obot to accommodate it.

It doesn't rely on bundle and category metadata anymore. Category can be used to defined bigger group other than bundle.