### PR TITLE
Fix: Correct Outlook credential reference

### DIFF
--- a/outlook/calendar/credential/tool.gpt
+++ b/outlook/calendar/credential/tool.gpt
@@ -4,9 +4,9 @@ Type: credential
 
 ---
 Name: outlook-cal-cred
-Tools: ../../oauth2
+Tools: ../../../oauth2
 
-#!sys.call ../../oauth2
+#!sys.call ../../../oauth2
 
 {
 	"oauthInfo": {

--- a/outlook/mail/credential/tool.gpt
+++ b/outlook/mail/credential/tool.gpt
@@ -1,12 +1,12 @@
 Name: Outlook Mail OAuth Write Credential
-Share Credential: outlook-cal-cred as outlook.mail.write
+Share Credential: outlook-mail-cred as outlook.mail.write
 Type: credential
 
 ---
 Name: outlook-mail-cred
-Tools: ../../oauth2
+Tools: ../../../oauth2
 
-#!sys.call ../../oauth2
+#!sys.call ../../../oauth2
 
 {
 	"oauthInfo": {


### PR DESCRIPTION
The outlook credentials had two problems:
1. Not enough dots
2. Imposter syndrome

Signed-off-by: Craig Jellick <craig@acorn.io>
