### PR TITLE
fix: google search workspace id extraction and session management

### DIFF
--- a/google/search/package-lock.json
+++ b/google/search/package-lock.json
@@ -6,8 +6,11 @@
     "": {
       "dependencies": {
         "@gptscript-ai/gptscript": "^0.9.5",
+        "@isaacs/ttlcache": "^1.4.1",
         "@playwright/test": "^1.41.2",
+        "@types/async-lock": "^1.4.2",
         "@types/turndown": "^5.0.4",
+        "async-lock": "^1.4.1",
         "async-mutex": "^0.5.0",
         "body-parser": "^1.20.2",
         "cheerio": "^1.0.0-rc.12",
@@ -206,6 +209,15 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
+    "node_modules/@isaacs/ttlcache": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/ttlcache/-/ttlcache-1.4.1.tgz",
+      "integrity": "sha512-RQgQ4uQ+pLbqXfOmieB91ejmLwvSgv9nLx6sT6sD83s7umBypgg+OIBOBbEUiJXrfpnp9j0mRhYYdzp9uqq3lA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
@@ -319,6 +331,12 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
       "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/async-lock": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@types/async-lock/-/async-lock-1.4.2.tgz",
+      "integrity": "sha512-HlZ6Dcr205BmNhwkdXqrg2vkFMN2PluI7Lgr8In3B3wE5PiQHhjRqtW/lGdVU9gw+sM0JcIDx2AN+cW8oSWIcw==",
       "license": "MIT"
     },
     "node_modules/@types/body-parser": {
@@ -951,6 +969,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/async-lock": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/async-lock/-/async-lock-1.4.1.tgz",
+      "integrity": "sha512-Az2ZTpuytrtqENulXwO3GGv1Bztugx6TT37NIo7imr/Qo0gsYiGtSdBa2B6fsXhTpVZDNfu1Qn3pk531e3q+nQ==",
+      "license": "MIT"
     },
     "node_modules/async-mutex": {
       "version": "0.5.0",

--- a/google/search/package.json
+++ b/google/search/package.json
@@ -19,8 +19,11 @@
   },
   "dependencies": {
     "@gptscript-ai/gptscript": "^0.9.5",
+    "@isaacs/ttlcache": "^1.4.1",
     "@playwright/test": "^1.41.2",
+    "@types/async-lock": "^1.4.2",
     "@types/turndown": "^5.0.4",
+    "async-lock": "^1.4.1",
     "async-mutex": "^0.5.0",
     "body-parser": "^1.20.2",
     "cheerio": "^1.0.0-rc.12",

--- a/google/search/src/server.ts
+++ b/google/search/src/server.ts
@@ -70,7 +70,7 @@ async function main (): Promise<void> {
     stopped = true
     console.error('Daemon shutting down...')
     try {
-      await sessionManager.cleanup() // Ensure all browsers are closed
+      await sessionManager.destroy() // Ensure all browsers are closed
     } catch (err) {
       console.error('Error during session cleanup:', err)
     }

--- a/google/search/src/session.ts
+++ b/google/search/src/session.ts
@@ -5,7 +5,8 @@ import { type IncomingHttpHeaders } from 'node:http'
 import { createHash } from 'node:crypto'
 import { type BrowserContext } from 'playwright'
 import { newBrowserContext } from './context.ts'
-import { Mutex } from 'async-mutex'
+import TTLCache from '@isaacs/ttlcache'
+import AsyncLock from 'async-lock'
 
 const APP_CACHE_DIR = (() => {
   const homeDir = os.homedir()
@@ -34,117 +35,163 @@ async function clearAppCacheDir (): Promise<void> {
 // Call the function at startup
 await clearAppCacheDir()
 
-let sessionManager: SessionManager | undefined
+const SESSION_TTL = 5 * 60 * 1000 // 5 minutes
+const LOCK_TIMEOUT = 10000 // 10 seconds timeout for locks
 
-interface ManagedSession {
-  session: Session
-  cleanupTimeout?: NodeJS.Timeout
+interface Session {
+  sessionId: string
+  browserContext: BrowserContext
+  active: number
 }
 
 export class SessionManager {
-  private readonly sessions = new Map<string, ManagedSession>()
-  private readonly sessionsLock: Mutex = new Mutex()
+  private static instance: SessionManager | null = null
+  private sessionCache: TTLCache<string, Session>
+  private lock: AsyncLock
+  private isDestroyed = false
 
-  private constructor () {
-  }
-
-  static async create (): Promise<SessionManager> {
-    sessionManager ??= new SessionManager()
-    return sessionManager
-  }
-
-  async withSession (sessionId: string, fn: (browserContext: BrowserContext) => Promise<void>): Promise<void> {
-    let managedSession: ManagedSession | undefined
-    await this.sessionsLock.runExclusive(async () => {
-      managedSession = this.sessions.get(sessionId)
-      if (managedSession == null) {
-        managedSession = { session: await Session.create(sessionId) }
-        this.sessions.set(sessionId, managedSession)
-      }
-      if (managedSession.cleanupTimeout != null) clearTimeout(managedSession.cleanupTimeout)
+  private constructor() {
+    this.sessionCache = new TTLCache<string, Session>({
+      ttl: SESSION_TTL,
+      max: 10000,
+      updateAgeOnGet: true,
+      noDisposeOnSet: true,
+      dispose: async (session: Session, sessionId: string, reason: string) => {
+        console.info(`[Session ${sessionId}] Disposing session due to ${reason}.`)
+        await this.destroySession(session)
+      },
     })
 
-    if (managedSession?.session.browserContext != null) {
-      await fn(managedSession.session.browserContext)
-      managedSession.cleanupTimeout = setTimeout(() => {
-        void this.deleteSession(sessionId)
-      }, SESSION_TTL)
+    this.lock = new AsyncLock({ timeout: LOCK_TIMEOUT })
+  }
+
+  public static create(): SessionManager {
+    if (!this.instance) {
+      this.instance = new SessionManager()
+    }
+    return this.instance
+  }
+
+  private async acquireSession(sessionId: string): Promise<Session> {
+    return await this.lock.acquire(sessionId, async () => {
+      if (this.isDestroyed) throw new Error('SessionManager is destroyed.')
+
+      let session = this.sessionCache.get(sessionId)
+      if (!session) {
+        console.info(`[SessionManager] Creating new session for ${sessionId}.`)
+        session = await this.createSession(sessionId)
+        this.sessionCache.set(sessionId, session)
+      }
+
+      session.active++
+      console.info(`[Session ${session.sessionId}] Acquired active=${session.active}.`)
+      return session
+    })
+  }
+
+  private async releaseSession(sessionId: string): Promise<void> {
+    await this.lock.acquire(sessionId, async () => {
+      const session = this.sessionCache.get(sessionId)
+      if (!session) {
+        console.warn(`[Session ${sessionId}] Release attempted but session does not exist.`)
+        return
+      }
+
+      session.active--
+      console.info(`[Session ${session.sessionId}] Released active=${session.active}.`)
+    })
+  }
+
+  private async createSession(sessionId: string): Promise<Session> {
+    const sessionDir = path.resolve(APP_CACHE_DIR, 'browser_sessions', sessionId)
+    await fs.mkdir(sessionDir, { recursive: true })
+    const browserContext = await newBrowserContext(sessionDir)
+    console.info(`[Session ${sessionId}] Created session (dir: ${sessionDir}).`)
+    return { sessionId, browserContext, active: 0 }
+  }
+
+  private async destroySession(session: Session, force: boolean = false): Promise<void> {
+    await this.lock.acquire(session.sessionId, async () => {
+      if (force) {
+        console.warn(`[Session ${session.sessionId}] Force destroying session.`)
+      } else if (session.active > 0) {
+        console.warn(`[Session ${session.sessionId}] Dispose attempted while active=${session.active}.`)
+        return
+      }
+
+      console.info(`[Session ${session.sessionId}] Finalizing session.`)
+      try {
+        await session.browserContext.close()
+        console.info(`[Session ${session.sessionId}] Browser context closed.`)
+      } catch (err) {
+        console.error(`Error closing browser context for session ${session.sessionId}: ${err}`)
+      }
+
+      try {
+        const sessionDir = path.resolve(APP_CACHE_DIR, 'browser_sessions', session.sessionId)
+        await fs.rm(sessionDir, { recursive: true, force: true })
+        console.info(`[Session ${session.sessionId}] Session directory removed.`)
+      } catch (err) {
+        console.error(`Error removing session directory for session ${session.sessionId}: ${err}`)
+      }
+    })
+  }
+
+  public async withSession<T>(sessionId: string, fn: (ctx: BrowserContext) => Promise<T>): Promise<T> {
+    const session = await this.acquireSession(sessionId)
+    try {
+      console.info(`[SessionManager] Running work on session ${session.sessionId}.`)
+      return await fn(session.browserContext)
+    } catch (err) {
+      console.error(`Error during work on session ${session.sessionId}: ${err}`)
+      throw err
+    } finally {
+      await this.releaseSession(sessionId)
     }
   }
 
-  private async deleteSession (sessionId: string): Promise<void> {
-    await this.sessionsLock.runExclusive(async () => {
-      const managedSession = this.sessions.get(sessionId)
-      if (managedSession != null) {
-        const { session, cleanupTimeout } = managedSession
-        if (cleanupTimeout != null) clearTimeout(cleanupTimeout)
-        await session?.close()
-        this.sessions.delete(sessionId)
-      }
-    })
-  }
+  public async destroy(): Promise<void> {
+    console.info('[SessionManager] Destroying all sessions...')
+    this.isDestroyed = true
 
-  async cleanup (): Promise<void> {
-    console.log('Cleaning up all sessions...')
-    await this.sessionsLock.runExclusive(async () => {
-      for (const [sessionId, managedSession] of this.sessions.entries()) {
-        await managedSession.session.close()
-        this.sessions.delete(sessionId)
-      }
-    })
+    const sessionIds = Array.from(this.sessionCache.keys())
+    for (const sessionId of sessionIds) {
+      await this.lock.acquire(sessionId, async () => {
+        const session = this.sessionCache.get(sessionId)
+        if (session) {
+          console.info(`[Session ${sessionId}] Closing session as part of destroy().`)
+          await this.destroySession(session, true)
+        }
+      })
+    }
+
+    this.sessionCache.clear()
+    SessionManager.instance = null
+    console.info('[SessionManager] Destroy complete.')
   }
 }
 
-const SESSION_TTL = 5 * 60 * 1000 // 5 minutes
-
-class Session {
-  sessionId: string
-  sessionDir: string = ''
-  browserContext?: BrowserContext
-
-  private constructor (sessionId: string) {
-    this.sessionId = sessionId
-  }
-
-  static async create (sessionId: string): Promise<Session> {
-    const session = new Session(sessionId)
-    session.sessionDir = await mkSessionDir(sessionId)
-    session.browserContext = await newBrowserContext(session.sessionDir)
-    return session
-  }
-
-  async close (): Promise<void> {
-    await this.browserContext?.close()
-    await fs.rm(this.sessionDir, { recursive: true })
-  }
-}
-
-async function mkSessionDir (sessionId: string): Promise<string> {
-  const sessionDir = path.resolve(APP_CACHE_DIR, 'browser_sessions', sessionId)
-  await fs.mkdir(sessionDir, { recursive: true })
-  return sessionDir
-}
-
-export function getSessionId (headers: IncomingHttpHeaders | undefined): string {
-  const workspaceId = getWorkspaceId(headers?.['x-gptscript-env'])
+export function getSessionId(headers: IncomingHttpHeaders): string {
+  const workspaceId = getGPTScriptEnv(headers, 'GPTSCRIPT_WORKSPACE_ID')
   if (workspaceId == null) throw new Error('No GPTScript workspace ID provided')
 
   return createHash('sha256').update(workspaceId).digest('hex').substring(0, 16)
 }
 
-function getWorkspaceId (envHeader: string | string[] | undefined): string | undefined {
-  const envArray = Array.isArray(envHeader) ? envHeader : [envHeader]
-  for (const env of envArray) {
-    if (env == null) {
-      continue
-    }
+export function getWorkspaceId(headers: IncomingHttpHeaders): string | undefined {
+  return getGPTScriptEnv(headers, 'GPTSCRIPT_WORKSPACE_ID')
+}
 
+export function getGPTScriptEnv(headers: IncomingHttpHeaders, envKey: string): string | undefined {
+  const envHeader = headers?.['x-gptscript-env']
+  const envArray = Array.isArray(envHeader) ? envHeader : [envHeader]
+
+  for (const env of envArray) {
+    if (env == null) continue
     for (const pair of env.split(',')) {
-      const [key, value] = pair.split('=')
-      if (key === 'GPTSCRIPT_WORKSPACE_ID') {
-        return value ?? process.env.GPTSCRIPT_WORKSPACE_ID
-      }
+      const [key, value] = pair.split('=').map((part) => part.trim())
+      if (key === envKey) return value
     }
   }
-  return process.env.GPTSCRIPT_WORKSPACE_ID
+  return undefined
 }


### PR DESCRIPTION
Properly extract the thread workspace ID from the `X-GPTSCRIPT-ENV` header.

Before this change, the tool would fail to extract it and would fallback on the value set in its environment variables. Since the session ID -- used for managing sessions -- is derived from the extracted workspace ID and the value in the daemon tool's env is static, every thread ended up sharing the same session.

Additionally, redesign session management to:
- use a third-party TTL cache package to handle session expiration and
  cleanup
- use session scoped locks to reduce contention when provisioning new
  sessions
- remove potential race conditions


Addresses:
- https://github.com/obot-platform/obot/issues/1651
- https://github.com/obot-platform/obot/issues/1653