### PR TITLE
fix: wordpress auth instruction update

### DIFF
--- a/wordpress/credential/tool.gpt
+++ b/wordpress/credential/tool.gpt
@@ -12,8 +12,8 @@ Tools: ../../generic-credential
 	"promptInfo": {
 		"fields" : [
 		    {
-				"name": "Wordpress Site",
-				"description": "Your Wordpress Site URL",
+				"name": "Wordpress Site URL",
+				"description": "Enter your WordPress site URL in the format: https://example.com. Do not include a trailing slash or suffix like /wp-admin or /wp-json.",
 				"env": "WORDPRESS_SITE"
 			},
 			{
@@ -22,12 +22,12 @@ Tools: ../../generic-credential
                 "env": "WORDPRESS_USERNAME"
             },
 			{
-				"name": "Wordpress Password",
-				"description": "Your Wordpress password, it's recommended to use an application password.",
+				"name": "Wordpress Application Password",
+				"description": "Your Wordpress application password. Note that this is different from your Wordpress password.",
 				"env": "WORDPRESS_PASSWORD",
 				"sensitive": true
 			}
 		],
-		"message": "Enter your Wordpress site url, username and password or application password."
+		"message": "WARNING: This tool does not support WordPress.com sites.\nPREREQUISITES:\n1. Create an application password to enable post creation:\n   - Go to your WordPress site admin dashboard.\n   - In the left sidebar, click `Users`, then edit your user profile.\n   - Scroll to the `Application Passwords` section and click `Add New Application Password`.\n2. Configure permalinks for the WordPress API to work:\n   - In the dashboard, hover over `Settings` and select `Permalinks`.\n   - Choose any structure other than `Plain` and save the changes."
 	}
 }

--- a/wordpress/tool.gpt
+++ b/wordpress/tool.gpt
@@ -1,6 +1,6 @@
 ---
 Name: Wordpress
-Description: Tools for interacting with self-hosted and hosted Wordpress sites that support basic auth.
+Description: Tools for interacting with self-hosted and hosted Wordpress sites that support basic auth. Wordpress.com sites are not supported.
 Metadata: bundle: true
 Share Tools: List Users, Get User, List Posts, Retrieve Post, Create Post, Update Post, Delete Post, Get Site Settings
 


### PR DESCRIPTION
- Add detailed instructions to the Wordpress tool auth page, includes guidelines of site url format, as well as prerequisites to setup application password & how-to config permalinks to enable API endpoint path. Hopefully this makes the auth setup UX better.
- Notify user that `wordpress.com` sites are NOT supported. We can add more if in the future we found any other platforms are not compatible. https://github.com/obot-platform/obot/issues/1650


I think it would be nice if the UI can display the message in a more structured format.

<img width="384" alt="Screenshot 2025-02-05 at 4 39 45 PM" src="https://github.com/user-attachments/assets/e281d02a-fd7c-435b-a9b8-31bbc43e71db" />
<img width="510" alt="Screenshot 2025-02-05 at 4 39 57 PM" src="https://github.com/user-attachments/assets/4149f4e6-6402-45a6-b73c-b1c1a064439c" />
