### PR TITLE
fix: use fusejs to filter search results for slack channels and users

### DIFF
--- a/slack/package-lock.json
+++ b/slack/package-lock.json
@@ -11,7 +11,8 @@
       "dependencies": {
         "@gptscript-ai/gptscript": "github:gptscript-ai/node-gptscript#d4b222c34e757b62429dc43ae9cc44aa3f6c9700",
         "@slack/web-api": "^7.3.2",
-        "async-mutex": "^0.5.0"
+        "async-mutex": "^0.5.0",
+        "fuse.js": "^7.1.0"
       }
     },
     "node_modules/@gptscript-ai/gptscript": {
@@ -238,6 +239,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/fuse.js": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-7.1.0.tgz",
+      "integrity": "sha512-trLf4SzuuUxfusZADLINj+dE8clK1frKdmqiJNb1Es75fmI5oY6X2mxLVUciLLjxqw/xr72Dhy+lER6dGd02FQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/is-electron": {

--- a/slack/package.json
+++ b/slack/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@gptscript-ai/gptscript": "github:gptscript-ai/node-gptscript#d4b222c34e757b62429dc43ae9cc44aa3f6c9700",
     "@slack/web-api": "^7.3.2",
-    "async-mutex": "^0.5.0"
+    "async-mutex": "^0.5.0",
+    "fuse.js": "^7.1.0"
   }
 }

--- a/slack/src/tools.js
+++ b/slack/src/tools.js
@@ -46,7 +46,8 @@ export async function searchChannels(webClient, query) {
         result?.channels ?? [],
         {
             keys: ['name'],
-            threshold: 0.4
+            threshold: 0.4,
+            findAllMatches: true
         }
     )).search(query).map(result => result.item)
 
@@ -216,12 +217,14 @@ export async function listUsers(webClient) {
 
 export async function searchUsers(webClient, query) {
     const users = await webClient.users.list()
-    const matchingUsers = users.members.filter(user => {
-        return user.name.includes(query) ||
-            user.profile.real_name.includes(query) ||
-            user.profile.display_name.includes(query)
+    const fuse = new Fuse(users.members, {
+        keys: ['name', 'profile.real_name', 'profile.display_name'],
+        threshold: 0.5,
+        findAllMatches: true
     })
-    if (matchingUsers.length === 0) {
+    const matchingUsers = fuse.search(query).map(result => result.item)
+
+    if (!matchingUsers || matchingUsers.length === 0) {
         console.log('No users found')
         return
     }


### PR DESCRIPTION
Update the `Search Channels` and `Search Users` tools to use Fuse.js to filter slack channel names and user names by similarity to the query string.

Note: This may not return exact matches, but will allow LLMs to filter the channels and users down to results with similar names.

Addresses https://github.com/obot-platform/obot/issues/1660

