### PR TITLE
enhance: update prompt to format wordpress post content

### DIFF
--- a/wordpress/tool.gpt
+++ b/wordpress/tool.gpt
@@ -61,11 +61,11 @@ Share Context: Wordpress Context
 
 ---
 Name: Create Post
-Description: Create a post in user'swordpress site
+Description: Create a post in user'swordpress site. Wordpress post does NOT render markdown syntax. Make sure use html like tags to format the content.
 Credential: ./credential
 Share Context: Wordpress Context
 Param: title: the title of the post
-Param: content: the content of the post
+Param: content: the content of the post.
 Param: status: (optional) the status of the post, must be one of: publish, future, draft, pending, private, default is publish
 Param: comment_status: (optional) the comment status of the post, must be one of: open, closed. default is open
 Param: sticky: (optional) whether the post is sticky to the top of the page, default is false
@@ -81,7 +81,7 @@ Param: ping_status: (optional) the ping status of the post, must be one of: open
 
 ---
 Name: Update Post
-Description: Update a post in user's wordpress site. Only the fields that are provided will be updated.
+Description: Update a post in user's wordpress site. Only the fields that are provided will be updated. Wordpress post does NOT render markdown syntax. Make sure use html like tags to format the content.
 Credential: ./credential
 Share Context: Wordpress Context
 Param: post_id: the id of the post to update
@@ -122,7 +122,7 @@ Share Context: ../time
 You have access to a set of tools to interact with a Wordpress workspace.
 
 Display all dates and times in the user's preferred timezone. When the user gives values for dates and times, assume they are in the user's preferred timezone unless otherwise specified by the user.
-Wordpress post doesn't render markdown syntax, so when you create or update a post, you should not fill the content with markdown syntax.
+Wordpress post doesn't render markdown syntax, use html like tags to format the content.
 Wordpress post supports a list of different formats, here are the definitions:
 - standard: The default post format.
 - aside: Typically styled without a title. Similar to a Facebook note update.

--- a/wordpress/tool.gpt
+++ b/wordpress/tool.gpt
@@ -123,7 +123,7 @@ You have access to a set of tools to interact with a Wordpress workspace.
 
 Display all dates and times in the user's preferred timezone. When the user gives values for dates and times, assume they are in the user's preferred timezone unless otherwise specified by the user.
 You MUST use HTML tags to format the content. WordPress posts do NOT render markdown syntax.
-WordPress posts support a list of different formats, here are the definitions:
+WordPress posts support the following formats:
 - standard: The default post format.
 - aside: Typically styled without a title. Similar to a Facebook note update.
 - gallery: A gallery of images. Post will likely contain a gallery shortcode and will have image attachments.

--- a/wordpress/tool.gpt
+++ b/wordpress/tool.gpt
@@ -61,12 +61,12 @@ Share Context: Wordpress Context
 
 ---
 Name: Create Post
-Description: Create a post in user'swordpress site. Wordpress post does NOT render markdown syntax. Make sure use html like tags to format the content.
+Description: Create a post in user'swordpress site. Use HTML tags to format the content, for example, <strong>Bold Text</strong> for bold text.
 Credential: ./credential
 Share Context: Wordpress Context
 Param: title: the title of the post
 Param: content: the content of the post.
-Param: status: (optional) the status of the post, must be one of: publish, future, draft, pending, private, default is publish
+Param: status: (optional) the status of the post, must be one of: publish, future, draft, pending, private, default is draft.
 Param: comment_status: (optional) the comment status of the post, must be one of: open, closed. default is open
 Param: sticky: (optional) whether the post is sticky to the top of the page, default is false
 Param: password: (optional) the password of the post, default is None
@@ -81,7 +81,7 @@ Param: ping_status: (optional) the ping status of the post, must be one of: open
 
 ---
 Name: Update Post
-Description: Update a post in user's wordpress site. Only the fields that are provided will be updated. Wordpress post does NOT render markdown syntax. Make sure use html like tags to format the content.
+Description: Update a post in user's wordpress site. Only the fields that are provided will be updated. Use HTML tags to format the content, for example, <strong>Bold Text</strong> for bold text.
 Credential: ./credential
 Share Context: Wordpress Context
 Param: post_id: the id of the post to update
@@ -122,8 +122,8 @@ Share Context: ../time
 You have access to a set of tools to interact with a Wordpress workspace.
 
 Display all dates and times in the user's preferred timezone. When the user gives values for dates and times, assume they are in the user's preferred timezone unless otherwise specified by the user.
-Wordpress post doesn't render markdown syntax, use html like tags to format the content.
-Wordpress post supports a list of different formats, here are the definitions:
+You MUST use HTML tags to format the content, WordPress posts do NOT render markdown syntax.
+WordPress posts support a list of different formats, here are the definitions:
 - standard: The default post format.
 - aside: Typically styled without a title. Similar to a Facebook note update.
 - gallery: A gallery of images. Post will likely contain a gallery shortcode and will have image attachments.

--- a/wordpress/tool.gpt
+++ b/wordpress/tool.gpt
@@ -81,7 +81,7 @@ Param: ping_status: (optional) the ping status of the post, must be one of: open
 
 ---
 Name: Update Post
-Description: Update a post in user's wordpress site. Only the fields that are provided will be updated. Use HTML tags to format the content, for example, <strong>Bold Text</strong> for bold text.
+Description: Update a post in user's Wordpress site. Only the fields that are provided will be updated. Use HTML tags to format the content, for example, <strong>Bold Text</strong> for bold text.
 Credential: ./credential
 Share Context: Wordpress Context
 Param: post_id: the id of the post to update

--- a/wordpress/tool.gpt
+++ b/wordpress/tool.gpt
@@ -122,7 +122,7 @@ Share Context: ../time
 You have access to a set of tools to interact with a Wordpress workspace.
 
 Display all dates and times in the user's preferred timezone. When the user gives values for dates and times, assume they are in the user's preferred timezone unless otherwise specified by the user.
-You MUST use HTML tags to format the content, WordPress posts do NOT render markdown syntax.
+You MUST use HTML tags to format the content. WordPress posts do NOT render markdown syntax.
 WordPress posts support a list of different formats, here are the definitions:
 - standard: The default post format.
 - aside: Typically styled without a title. Similar to a Facebook note update.

--- a/wordpress/tool.gpt
+++ b/wordpress/tool.gpt
@@ -61,7 +61,7 @@ Share Context: Wordpress Context
 
 ---
 Name: Create Post
-Description: Create a post in user'swordpress site. Use HTML tags to format the content, for example, <strong>Bold Text</strong> for bold text.
+Description: Create a post in user'swordpress site. Use HTML tags to format the content, for example, <strong>Bold Text</strong> for bold text. By default, the post will be created as a draft, do NOT set status to publish unless it is confirmed by the user.
 Credential: ./credential
 Share Context: Wordpress Context
 Param: title: the title of the post

--- a/wordpress/tool.gpt
+++ b/wordpress/tool.gpt
@@ -61,7 +61,7 @@ Share Context: Wordpress Context
 
 ---
 Name: Create Post
-Description: Create a post in user'swordpress site. Use HTML tags to format the content, for example, <strong>Bold Text</strong> for bold text. By default, the post will be created as a draft, do NOT set status to publish unless it is confirmed by the user.
+Description: Create a post in user's Wordpress site. Use HTML tags to format the content, for example, <strong>Bold Text</strong> for bold text. By default, the post will be created as a draft. Do NOT set status to publish unless it is confirmed by the user.
 Credential: ./credential
 Share Context: Wordpress Context
 Param: title: the title of the post

--- a/wordpress/tools/posts.py
+++ b/wordpress/tools/posts.py
@@ -157,7 +157,7 @@ def create_post(client):
     content = os.getenv("CONTENT", "")
     if title == "" and content == "":
         raise ValueError("Error: At least one of title or content must be provided.")
-    status = os.getenv("STATUS", "publish").lower()
+    status = os.getenv("STATUS", "draft").lower()
     status_enum = ["publish", "future", "draft", "pending", "private"]
     if status not in status_enum:
         raise ValueError(


### PR DESCRIPTION
- Prompt the agent to format post with HTML tags, not markdown syntax. https://github.com/obot-platform/obot/issues/1665
- Also change default post status to `draft`.