### PR TITLE
Fix: Add newline to wordpress cred description

### DIFF
--- a/wordpress/credential/tool.gpt
+++ b/wordpress/credential/tool.gpt
@@ -28,6 +28,6 @@ Tools: ../../generic-credential
 				"sensitive": true
 			}
 		],
-		"message": "WARNING: This tool does not support WordPress.com sites.\nPREREQUISITES:\n1. Create an application password to enable post creation:\n   - Go to your WordPress site admin dashboard.\n   - In the left sidebar, click `Users`, then edit your user profile.\n   - Scroll to the `Application Passwords` section and click `Add New Application Password`.\n2. Configure permalinks for the WordPress API to work:\n   - In the dashboard, hover over `Settings` and select `Permalinks`.\n   - Choose any structure other than `Plain` and save the changes."
+		"message": "WARNING: This tool does not support WordPress.com sites.\n\nPREREQUISITES:\n1. Create an application password to enable post creation:\n   - Go to your WordPress site admin dashboard.\n   - In the left sidebar, click `Users`, then edit your user profile.\n   - Scroll to the `Application Passwords` section and click `Add New Application Password`.\n2. Configure permalinks for the WordPress API to work:\n   - In the dashboard, hover over `Settings` and select `Permalinks`.\n   - Choose any structure other than `Plain` and save the changes."
 	}
 }


### PR DESCRIPTION
Signed-off-by: Craig Jellick <craig@acorn.io>
