### PR TITLE
add: basic tavily search tool

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -1,46 +1,66 @@
 tools:
   sendgrid:
     reference: ./sendgrid
+    all: true
   file-summarizer:
     reference: ./file-summarizer
+    all: true
   database:
     reference: ./database
   zoom:
     reference: ./zoom
+    all: true
   atlassian-jira:
     reference: ./atlassian/jira
+    all: true
   wordpress:
     reference: ./wordpress
+    all: true
   excel:
     reference: ./excel
+    all: true
   browser:
     reference: ./browser
+    all: true
   bluesky:
     reference: ./bluesky
+    all: true
   slack:
     reference: ./slack
+    all: true
   linkedin-publishing:
     reference: ./linkedin-publishing
+    all: true
   notion:
     reference: ./notion
+    all: true
   google-docs:
     reference: ./google/docs
+    all: true
   google-gmail:
     reference: ./google/gmail
+    all: true
   google-search:
     reference: ./google/search
+    all: true
   google-sheets:
     reference: ./google/sheets
+    all: true
   gitlab:
     reference: ./gitlab
+    all: true
   images:
     reference: ./images
+    all: true
   outlook-mail:
     reference: ./outlook/mail
+    all: true
   outlook-calender:
     reference: ./outlook/calendar
+    all: true
   github:
     reference: ./github
+    all: true
   time:
     reference: ./time
   workspace-files:

--- a/search/tavily/credential/tool.gpt
+++ b/search/tavily/credential/tool.gpt
@@ -1,0 +1,22 @@
+Name: Tavily API Credential
+Share Credential: tavily-cred as tavily
+Type: credential
+
+---
+Name: tavily-cred
+Tools: ../../../generic-credential
+
+#!sys.call ../../../generic-credential
+
+{
+	"promptInfo": {
+		"fields" : [
+			{
+				"name": "Tavily API Key",
+				"env": "TAVILY_API_KEY",
+				"sensitive": true
+			}
+		],
+		"message": "Get your Tavily API Key at https://app.tavily.com/home."
+	}
+}

--- a/search/tavily/main.py
+++ b/search/tavily/main.py
@@ -1,0 +1,51 @@
+import logging
+import os
+import sys
+
+from tavily import TavilyClient
+from urllib3.util import parse_url
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: python main.py [search | extract]")
+        sys.exit(1)
+
+    command = sys.argv[1]
+    client = TavilyClient()  # env TAVILY_API_KEY required
+
+    match command:
+        case "search":
+            query = os.getenv("QUERY").strip()
+            if not query:
+                print("No search query provided")
+                sys.exit(1)
+            response = client.search(query)
+        case "extract":
+            url = parse_url(os.getenv("URL").strip())
+
+            # default to https:// if no scheme is provided
+            if not url.scheme:
+                url = parse_url("https://" + url.url.removeprefix("://"))
+
+            # Only http and https are supported
+            if url.scheme not in ["http", "https"]:
+                print("Invalid URL scheme: must be http or https")
+                sys.exit(1)
+
+            response = client.extract(url.url)
+        case _:
+            print(f"Unknown command: {command}")
+            sys.exit(1)
+
+    logging.basicConfig(stream=sys.stderr, level=logging.INFO)
+    if not response:
+        logging.error(f"Tavily - {command} - No results found")
+        print("No results found")
+        sys.exit(1)
+    logging.info(f"Tavily - response:\n{response}")
+    print(response)
+
+
+if __name__ == "__main__":
+    main()

--- a/search/tavily/main.py
+++ b/search/tavily/main.py
@@ -16,12 +16,15 @@ def main():
 
     match command:
         case "search":
-            query = os.getenv("QUERY").strip()
+            query = os.getenv("QUERY", "").strip()
             if not query:
                 print("No search query provided")
                 sys.exit(1)
 
-            include_domains = os.getenv("INCLUDE_DOMAINS").strip().split(",")
+            domains_str = os.getenv("INCLUDE_DOMAINS", "")
+            include_domains = [
+                domain.strip() for domain in domains_str.split(",") if domain.strip()
+            ]
             response = client.search(
                 query=query,
                 include_answer=False,  # no LLM-generated answer needed - we'll do that

--- a/search/tavily/main.py
+++ b/search/tavily/main.py
@@ -20,7 +20,20 @@ def main():
             if not query:
                 print("No search query provided")
                 sys.exit(1)
-            response = client.search(query)
+
+            include_domains = os.getenv("INCLUDE_DOMAINS").strip().split(",")
+            response = client.search(
+                query=query,
+                include_answer=False,  # no LLM-generated answer needed - we'll do that
+                include_raw_content=True,
+                max_results=20
+                if len(include_domains) == 0
+                else 5
+                * len(
+                    include_domains
+                ),  # broader search if general, more narrow if scoped to specific sites
+                include_domains=include_domains,
+            )
         case "extract":
             url = parse_url(os.getenv("URL").strip())
 

--- a/search/tavily/requirements.txt
+++ b/search/tavily/requirements.txt
@@ -1,0 +1,1 @@
+tavily-python==0.5.1

--- a/search/tavily/tool.gpt
+++ b/search/tavily/tool.gpt
@@ -10,6 +10,7 @@ Description: Search the Web with Tavily. This returns a list of search results s
 Credential: ./credential
 Share Context: Tavily Context
 Param: query: The search query
+Param: includeDomains: A comma-separated list of domains to specifically include in the search
 
 #!/usr/bin/env python3 ${GPTSCRIPT_TOOL_DIR}/main.py search
 

--- a/search/tavily/tool.gpt
+++ b/search/tavily/tool.gpt
@@ -1,0 +1,43 @@
+---
+Name: Tavily Web Search
+Description: Tools for searching the web using the Tavily API.
+Metadata: bundle: true
+Share Tools: Search, Read Site
+
+---
+Name: Search
+Description: Search the Web with Tavily. This returns a list of search results scored by relevance to the query and summarized.
+Credential: ./credential
+Share Context: Tavily Context
+Param: query: The search query
+
+#!/usr/bin/env python3 ${GPTSCRIPT_TOOL_DIR}/main.py search
+
+---
+Name: Read Site
+Description: Read a specific website with Tavily
+Credential: ./credential
+Share Context: Tavily Context
+Param: url: The URL of the website
+
+#!/usr/bin/env python3 ${GPTSCRIPT_TOOL_DIR}/main.py extract
+
+---
+!metadata:*:icon
+/admin/assets/tavily_icon.svg
+
+---
+Name: Tavily Context
+Type: context
+Share Context: ../../time
+
+#!sys.echo
+
+# Instructions for using Tavily Search Tools
+
+You have tools for searching the web using the Tavily API Service.
+For any user query that doesn't contain a URL, first use the Search tool to retrieve some results.
+If the returned content for the top results doesn't satisfy you in terms of answer quality, use the Read Site tool to extract the raw content from the top results until you're satisfied with the answer.
+Add the link to the sources to all of your answers.
+
+# End of instructions for using Tavily Search Tools


### PR DESCRIPTION
Simplest possible implementation (i.e. not using any of their [available options](https://docs.tavily.com/sdk/reference/python#parameters))

It will prompt the user for a Tavily API Key - there are 1k free credits per month on Tavily's free plan.

## Usage Example

### Web Search with relative date :heavy_check_mark: 

![Screenshot 2025-02-07 at 15-28-20 Tavily](https://github.com/user-attachments/assets/c054f73d-ffd2-4d8f-826b-08317154cb1b)

### Follow-Up to read more about one of the results :question: - Access to many resources seems to be denied

![Screenshot 2025-02-07 at 15-28-36 Tavily](https://github.com/user-attachments/assets/e64a2d5d-7906-41ad-a51c-6623048c25d3)

### Finally finding a page that doesn't block access

![Screenshot 2025-02-07 at 15-28-47 Tavily](https://github.com/user-attachments/assets/7e830b14-5af8-4b26-9122-3e30c8a6e685)



Issue https://github.com/obot-platform/obot/issues/1363