### PR TITLE
fix: oauth2: only return the credential once

### DIFF
--- a/oauth2/main.go
+++ b/oauth2/main.go
@@ -199,7 +199,6 @@ func mainErr() (err error) {
 			return fmt.Errorf("main: failed to marshal refreshed credential: %w", err)
 		}
 
-		fmt.Print(string(credJSON))
 		return nil
 	}
 


### PR DESCRIPTION
there is a `defer` higher up that prints the `credJSON`, so we shouldn't print it again down here.