### PR TITLE
Fix: return early when no message is found

### DIFF
--- a/outlook/mail/pkg/commands/listMessages.go
+++ b/outlook/mail/pkg/commands/listMessages.go
@@ -90,6 +90,10 @@ func ListMessages(ctx context.Context, folderID, start, end, limit string) error
 		})
 	}
 
+	if len(elements) == 0 {
+		return nil
+	}
+
 	datasetID, err := gptscriptClient.CreateDatasetWithElements(ctx, elements, gptscript.DatasetOptions{
 		Name:        fmt.Sprintf("%s_outlook_mail", folderID),
 		Description: "Outlook mail messages in folder " + folderID,


### PR DESCRIPTION
When no message is found given a folder, the list-message will fail and exit 1 because it can't create dataset with 0 elements. This is to bypass that