### PR TITLE
fix: redesign database tool to hide sqlite3 cli from llm

### DIFF
--- a/database/main.go
+++ b/database/main.go
@@ -71,8 +71,8 @@ func main() {
 		result, err = cmd.ListDatabaseTables(ctx, dbFile)
 	case "listDatabaseTableRows":
 		result, err = cmd.ListDatabaseTableRows(ctx, dbFile, os.Getenv("TABLE"))
-	case "runDatabaseCommand":
-		result, err = cmd.RunDatabaseCommand(ctx, dbFile, os.Getenv("SQLITE3_ARGS"))
+	case "runDatabaseSQL":
+		result, err = cmd.RunDatabaseCommand(ctx, dbFile, os.Getenv("SQL"), "-header")
 		if err == nil {
 			err = saveWorkspaceDB(ctx, g, dbWorkspacePath, dbFile, initialDBData)
 		}

--- a/database/pkg/cmd/context.go
+++ b/database/pkg/cmd/context.go
@@ -13,18 +13,14 @@ func DatabaseContext(ctx context.Context, dbFile *os.File) (string, error) {
 	var builder strings.Builder
 
 	// Add usage instructions
-	builder.WriteString(`# START INSTRUCTIONS: Run Database Command tool
+	builder.WriteString(`# START INSTRUCTIONS: Run Database SQL tool
 
 You have access to tools for interacting with a SQLite database.
-The "Run Database Command" tool is a wrapper around the sqlite3 CLI, and the "sqlite3_args" argument will be passed to it.
-Do not include a database file argument in the "sqlite3_args" argument. The database file is automatically passed to the sqlite3 CLI.
-**Ensure that all SQL statements are properly encapsulated in double quotes** to be recognized as complete inputs by the SQLite interface.
-For example, use "\"CREATE TABLE example (id INTEGER);\"", not CREATE TABLE example (id INTEGER);.
-This means you should wrap the entire SQL command string in double quotes, ensuring it is treated as a single argument.
+The "Run Database SQL" tool lets you run SQL against the SQLite3 database.
 Display all results from these tools and their schemas in markdown format.
 If the user refers to creating or modifying tables, assume they mean a SQLite3 table and not writing a table in a markdown file.
 
-# END INSTRUCTIONS: Run Database Command tool
+# END INSTRUCTIONS: Run Database SQL tool
 `)
 
 	// Add the schemas section
@@ -48,7 +44,7 @@ func getSchemas(ctx context.Context, dbFile *os.File) (string, error) {
 	query := `SELECT sql FROM sqlite_master WHERE type IN ('table', 'index', 'view', 'trigger') AND name NOT LIKE 'sqlite_%' ORDER BY name;`
 
 	// Execute the query using the RunDatabaseCommand function
-	output, err := RunDatabaseCommand(ctx, dbFile, fmt.Sprintf("%q", query))
+	output, err := RunDatabaseCommand(ctx, dbFile, query)
 	if err != nil {
 		return "", fmt.Errorf("error querying schemas: %w", err)
 	}

--- a/database/pkg/cmd/table.go
+++ b/database/pkg/cmd/table.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"strings"
 )
 
 type tables struct {
@@ -16,44 +15,29 @@ type Table struct {
 	Name string `json:"name,omitempty"`
 }
 
-// ListDatabaseTables returns a JSON object containing the list of tables in the database.
+// ListDatabaseTables returns a JSON string containing the list of tables in the database.
 func ListDatabaseTables(ctx context.Context, dbFile *os.File) (string, error) {
-	tables, err := listTables(ctx, dbFile)
-	if err != nil {
-		return "", fmt.Errorf("failed to list tables: %w", err)
-	}
-
-	content, err := json.Marshal(tables)
-	if err != nil {
-		return "", fmt.Errorf("failed to marshal tables to JSON: %w", err)
-	}
-
-	return string(content), nil
-}
-
-// listTables retrieves the list of tables in the database using RunDatabaseCommand.
-func listTables(ctx context.Context, dbFile *os.File) (tables, error) {
 	// Query to fetch table names
 	query := "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%';"
 
-	// Execute the query using RunDatabaseCommand
-	rawOutput, err := RunDatabaseCommand(ctx, dbFile, fmt.Sprintf("%q", query))
+	// Execute the query using RunDatabaseCommand with JSON output
+	output, err := RunDatabaseCommand(ctx, dbFile, query, "-json")
 	if err != nil {
-		return tables{}, fmt.Errorf("error executing query to list tables: %w", err)
+		return "", fmt.Errorf("error executing query to list tables: %w", err)
 	}
 
-	// Process the output
-	lines := strings.Split(strings.TrimSpace(rawOutput), "\n")
-	if len(lines) == 0 {
-		return tables{}, nil // No tables found
-	}
-
-	var result tables
-	for _, line := range lines {
-		if line = strings.TrimSpace(line); line != "" {
-			result.Tables = append(result.Tables, Table{Name: line})
+	var dbTables tables
+	if output != "" {
+		if err := json.Unmarshal([]byte(output), &(dbTables.Tables)); err != nil {
+			return "", fmt.Errorf("error parsing table names: %w", err)
 		}
 	}
 
-	return result, nil
+	// Marshal final result
+	data, err := json.Marshal(dbTables)
+	if err != nil {
+		return "", fmt.Errorf("error marshaling tables to JSON: %w", err)
+	}
+
+	return string(data), nil
 }

--- a/database/tool.gpt
+++ b/database/tool.gpt
@@ -3,15 +3,15 @@ Name: Database
 Description: Tools for interacting with a database
 Metadata: category: Capability
 Metadata: icon: https://cdn.jsdelivr.net/npm/@phosphor-icons/core@2/assets/duotone/database-duotone.svg
-Share Tools: Run Database Command
+Share Tools: Run Database SQL
 
 ---
-Name: Run Database Command
+Name: Run Database SQL
 Share Context: Database Context
-Description: Run the sqlite3 command with the given arguments against the SQLite database and print the results
-Param: sqlite3_args: Arguments to pass to the sqlite3 cli
+Description: Run SQL against the SQLite3 database and return the results
+Param: sql: SQL to run against the SQLite3 database (e.g. "SELECT * FROM users")
 
-#!${GPTSCRIPT_TOOL_DIR}/bin/gptscript-go-tool runDatabaseCommand
+#!${GPTSCRIPT_TOOL_DIR}/bin/gptscript-go-tool runDatabaseSQL
 
 ---
 Name: Database Context


### PR DESCRIPTION
Redesign the database tool to accept a single `sql` parameter and hide
the fact that it's running the sqlite3 command under the hood.

Also:
- Remove context to coax LLM into quoting argument strings
- Use the `-json` sqlite3 option to simplify the logic in tools
  that drive UI database capabilities
- Don't use shlex

Addresses https://github.com/obot-platform/obot/issues/1734#issue-2850199682


