### PR TITLE
feat: add a new slack tool to get thread messages using a link

### DIFF
--- a/slack/index.js
+++ b/slack/index.js
@@ -6,6 +6,7 @@ import {
   getDMThreadHistory,
   getMessageLink,
   getThreadHistory,
+  getThreadHistoryFromLink,
   listChannels,
   listUsers,
   search,
@@ -43,6 +44,9 @@ switch (command) {
     break
   case "getThreadHistory":
     await getThreadHistory(webClient, process.env.CHANNELID, process.env.THREADID, process.env.LIMIT)
+    break
+  case "getThreadHistoryFromLink":
+    await getThreadHistoryFromLink(webClient, process.env.MESSAGELINK, process.env.LIMIT)
     break
   case "searchMessages":
     await search(webClient, process.env.QUERY)

--- a/slack/src/tools.js
+++ b/slack/src/tools.js
@@ -132,6 +132,21 @@ export async function getThreadHistory(webClient, channelId, threadId, limit) {
     }
 }
 
+export async function getThreadHistoryFromLink(webClient, messageLink, limit) {
+    // Extract channel ID and message timestamp from the link
+    // Example link format: https://team.slack.com/archives/CHANNEL_ID/p1234567890123456
+    const matches = messageLink.match(/archives\/([A-Z0-9]+)\/p(\d+)/)
+    if (!matches) {
+        console.log('Invalid message link format')
+        process.exit(1)
+    }
+
+    const channelId = matches[1]
+    // Convert the timestamp to Slack's format (with decimal point)
+    const threadId = (matches[2].slice(0, -6) + '.' + matches[2].slice(-6))
+
+    await getThreadHistory(webClient, channelId, threadId, limit)
+}
 
 export async function search(webClient, query) {
     const result = await webClient.search.all({

--- a/slack/tool.gpt
+++ b/slack/tool.gpt
@@ -2,7 +2,7 @@
 Name: Slack
 Description: Tools for interacting with Slack
 Metadata: bundle: true
-Share Tools: List Channels, Search Channels, Get Channel History, Get Channel History by Time, Get Thread History, Search Messages, Send Message, Send Message in Thread, List Users, Search Users, Send DM, Send DM in Thread, Get Message Link, Get DM History, Get DM Thread History
+Share Tools: List Channels, Search Channels, Get Channel History, Get Channel History by Time, Get Thread History From Link, Get Thread History, Search Messages, Send Message, Send Message in Thread, List Users, Search Users, Send DM, Send DM in Thread, Get Message Link, Get DM History, Get DM Thread History
 
 ---
 Name: List Channels
@@ -48,6 +48,17 @@ Param: start: the start time in RFC 3339 format
 Param: end: the end time in RFC 3339 format
 
 #!/usr/bin/env node ${GPTSCRIPT_TOOL_DIR}/index.js getChannelHistoryByTime
+
+---
+Name: Get Thread History From Link
+Description: Get the chat history for a particular thread from a Slack message link
+Share Context: Slack Context
+Tools: github.com/gptscript-ai/datasets/filter
+Credential: ./credential
+Param: messageLink: the link to the first Slack message in the thread (example "https://team.slack.com/archives/CHANNEL_ID/p1234567890123456")
+Param: limit: the number of messages to return
+
+#!/usr/bin/env node ${GPTSCRIPT_TOOL_DIR}/index.js getThreadHistoryFromLink
 
 ---
 Name: Get Thread History


### PR DESCRIPTION
Add a new tool to support getting a thread using the Slack link from the first message in the thread.

e.g. `https://team.slack.com/archives/CHANNEL_ID/p1234567890123456`

This provides an escape hatch if the LLM has trouble searching for a thread or the user knows exactly which thread they want.

Addresses https://github.com/obot-platform/obot/issues/1753
