### PR TITLE
Chore: remove category for google search console tool

### DIFF
--- a/google/search-console/tool.gpt
+++ b/google/search-console/tool.gpt
@@ -42,9 +42,5 @@ Params: property: The GSC property id
 https://cdn.jsdelivr.net/npm/simple-icons@v13/icons/googlesearchconsole.svg
 
 ---
-!metadata:*:category
-Google Search Console
-
----
 !metadata:*:oauth
 google


### PR DESCRIPTION
Category is not need anymore to group a bundle tool. Instead it should be optional and should have a bigger scope.