### PR TITLE
fix: allow no object type for model list

### DIFF
--- a/openai-model-provider/proxy/validate.go
+++ b/openai-model-provider/proxy/validate.go
@@ -46,8 +46,8 @@ func (cfg *Config) Validate(toolPath string) error {
 		return handleValidationError(toolPath, "Invalid Response Format")
 	}
 
-	if modelsResp.Object != "list" || len(modelsResp.Data) == 0 {
-		return handleValidationError(toolPath, "Invalid Models Response")
+	if modelsResp.Object != "" && modelsResp.Object != "list" || len(modelsResp.Data) == 0 {
+		return handleValidationError(toolPath, fmt.Sprintf("Invalid Models Response: %d models", len(modelsResp.Data)))
 	}
 
 	return nil


### PR DESCRIPTION
The generic OpenAI compatible model provider requires that the models list returned have an Object parameter with value "list." This parameter is not included in some otherwise compatible model providers and it seems reasonable to not require this field.

For whatever it's worth: I consider this work to have been done in my free time.