### PR TITLE
chore: bump google search playwright dep

### DIFF
--- a/google/search/package-lock.json
+++ b/google/search/package-lock.json
@@ -7,7 +7,7 @@
       "dependencies": {
         "@gptscript-ai/gptscript": "^0.9.5",
         "@isaacs/ttlcache": "^1.4.1",
-        "@playwright/test": "^1.41.2",
+        "@playwright/test": "^1.50.1",
         "@types/async-lock": "^1.4.2",
         "@types/turndown": "^5.0.4",
         "async-lock": "^1.4.1",
@@ -17,7 +17,7 @@
         "env-paths": "^3.0.0",
         "express": "^4.18.2",
         "global-cache-dir": "^6.0.0",
-        "playwright": "^1.46.0",
+        "playwright": "^1.50.1",
         "ts-node-dev": "^2.0.0",
         "turndown": "^7.1.3"
       },
@@ -288,12 +288,12 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.47.2",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.47.2.tgz",
-      "integrity": "sha512-jTXRsoSPONAs8Za9QEQdyjFn+0ZQFjCiIztAIF6bi1HqhBzG9Ma7g1WotyiGqFSBRZjIEqMdT8RUlbk1QVhzCQ==",
+      "version": "1.50.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.50.1.tgz",
+      "integrity": "sha512-Jii3aBg+CEDpgnuDxEp/h7BimHcUTDlpEtce89xEumlJ5ef2hqepZ+PWp1DDpYC/VO9fmWVI1IlEaoI5fK9FXQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.47.2"
+        "playwright": "1.50.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -3995,12 +3995,12 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.47.2",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.47.2.tgz",
-      "integrity": "sha512-nx1cLMmQWqmA3UsnjaaokyoUpdVaaDhJhMoxX2qj3McpjnsqFHs516QAKYhqHAgOP+oCFTEOCOAaD1RgD/RQfA==",
+      "version": "1.50.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.50.1.tgz",
+      "integrity": "sha512-G8rwsOQJ63XG6BbKj2w5rHeavFjy5zynBA9zsJMMtBoe/Uf757oG12NXz6e6OirF7RCrTVAKFXbLmn1RbL7Qaw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.47.2"
+        "playwright-core": "1.50.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -4013,9 +4013,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.47.2",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.47.2.tgz",
-      "integrity": "sha512-3JvMfF+9LJfe16l7AbSmU555PaTl2tPyQsVInqm3id16pdDfvZ8TTZ/pyzmkbDrZTQefyzU7AIHlZqQnxpqHVQ==",
+      "version": "1.50.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.50.1.tgz",
+      "integrity": "sha512-ra9fsNWayuYumt+NiM069M6OkcRb1FZSK8bgi66AtpFoWkg2+y0bJSNmkFrWhMbEBbVKC/EruAHH3g0zmtwGmQ==",
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"

--- a/google/search/package.json
+++ b/google/search/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@gptscript-ai/gptscript": "^0.9.5",
     "@isaacs/ttlcache": "^1.4.1",
-    "@playwright/test": "^1.41.2",
+    "@playwright/test": "^1.50.1",
     "@types/async-lock": "^1.4.2",
     "@types/turndown": "^5.0.4",
     "async-lock": "^1.4.1",
@@ -30,7 +30,7 @@
     "env-paths": "^3.0.0",
     "express": "^4.18.2",
     "global-cache-dir": "^6.0.0",
-    "playwright": "^1.46.0",
+    "playwright": "^1.50.1",
     "ts-node-dev": "^2.0.0",
     "turndown": "^7.1.3"
   }


### PR DESCRIPTION
Bump the playwright dependency for compatibility with newer versions of chrome. This allows the google search tool to work with local Obot deployments more reliably.


