### PR TITLE
chore: add tool bundle metadata to search tools

### DIFF
--- a/google/search/tool.gpt
+++ b/google/search/tool.gpt
@@ -24,3 +24,7 @@ Metadata: index: false
 ---
 !metadata:*:icon
 /admin/assets/google_icon_small.png
+
+---
+!metadata:*:toolBundle
+Google Search

--- a/search/tavily/tool.gpt
+++ b/search/tavily/tool.gpt
@@ -28,6 +28,10 @@ Param: url: The URL of the website
 /admin/assets/tavily_icon.svg
 
 ---
+!metadata:*:toolBundle
+Tavily Search
+
+---
 Name: Tavily Context
 Type: context
 Share Context: ../../time


### PR DESCRIPTION
This helps distinguish between the search tools being used when events for said
tools are emitted.