### PR TITLE
Enhance: Add support to pull slack bot token

### DIFF
--- a/oauth2/main.go
+++ b/oauth2/main.go
@@ -29,6 +29,7 @@ type oauthInfo struct {
 	Integration   string   `json:"integration"`
 	Token         string   `json:"token"`
 	Scope         []string `json:"scope"`
+	UserScope     []string `json:"userScope"`
 	OptionalScope []string `json:"optionalScope"`
 }
 
@@ -226,6 +227,9 @@ func mainErr() (err error) {
 	q.Set("challenge", challenge)
 	if len(in.OAuthInfo.Scope) != 0 {
 		q.Set("scope", strings.Join(in.OAuthInfo.Scope, " "))
+	}
+	if len(in.OAuthInfo.UserScope) != 0 {
+		q.Set("user_scope", strings.Join(in.OAuthInfo.UserScope, " "))
 	}
 	if len(in.OAuthInfo.OptionalScope) != 0 {
 		q.Set("optional_scope", strings.Join(in.OAuthInfo.OptionalScope, " "))

--- a/slack/credential/bot.gpt
+++ b/slack/credential/bot.gpt
@@ -1,0 +1,32 @@
+Name: Slack OAuth Bot Credential
+Share Credential: slack-bot-cred as slack.bot.write
+Type: credential
+
+---
+Name: slack-bot-cred
+Tools: ../../oauth2
+
+#!sys.call ../../oauth2
+
+{
+	"oauthInfo": {
+		"integration": "slack",
+		"token": "SLACK_TOKEN",
+		"scope": [
+			"chat:write",
+			"im:write",
+			"users:read"
+		]
+	},
+	"promptInfo": {
+        "fields" : [
+            {
+                "name": "Slack API Key",
+                "description": "A Bot token for your Slack account.",
+                "sensitive": true,
+                "env": "SLACK_TOKEN"
+            }
+        ],
+        "message": "Enter your Slack User or Bot OAuth Token."
+    }
+}

--- a/slack/credential/tool.gpt
+++ b/slack/credential/tool.gpt
@@ -12,7 +12,7 @@ Tools: ../../oauth2
 	"oauthInfo": {
 		"integration": "slack",
 		"token": "SLACK_TOKEN",
-		"scope": [
+		"userScope": [
 			"channels:history",
 			"groups:history",
 			"im:history",
@@ -34,7 +34,7 @@ Tools: ../../oauth2
         "fields" : [
             {
                 "name": "Slack API Key",
-                "description": "An OAuth User or Bot token for your GitHub account.",
+                "description": "An OAuth User or Bot token for your Slack account.",
                 "sensitive": true,
                 "env": "SLACK_TOKEN"
             }

--- a/slack/tool.gpt
+++ b/slack/tool.gpt
@@ -2,7 +2,7 @@
 Name: Slack
 Description: Tools for interacting with Slack
 Metadata: bundle: true
-Share Tools: List Channels, Search Channels, Get Channel History, Get Channel History by Time, Get Thread History From Link, Get Thread History, Search Messages, Send Message, Send Message in Thread, List Users, Search Users, Send DM, Send DM in Thread, Get Message Link, Get DM History, Get DM Thread History
+Share Tools: List Channels, Search Channels, Get Channel History, Get Channel History by Time, Get Thread History From Link, Get Thread History, Search Messages, Send Message, Send Message in Thread, List Users, Search Users, Send DM, Send DM in Thread, Get Message Link, Get DM History, Get DM Thread History, Send Direct Message As Bot
 
 ---
 Name: List Channels
@@ -184,6 +184,16 @@ Param: limit: the number of messages to return
 
 #!/usr/bin/env node ${GPTSCRIPT_TOOL_DIR}/index.js getDMThreadHistory
 
+---
+Name: Send Direct Message As Bot
+Description: Send a direct message as a bot or an app in the Slack workspace
+Share Context: Slack Context
+Credential: ./credential/bot.gpt
+Share Tools: List Users, Search Users
+Param: userids: comma-separated list of user IDs to send the message to for a group message (example: USER1ID,USER2ID), or just one ID for an individual message
+Param: text: the text to send
+
+#!/usr/bin/env node ${GPTSCRIPT_TOOL_DIR}/index.js sendDM
 ---
 Name: User Context
 Description: Get information about the logged in user.


### PR DESCRIPTION
Add support to use slack bot token to send message a bot. This is done by adding a new tool into slack bundle that consumes a separate credential that requests bot token. 