### PR TITLE
Enhance: Add slack bot tool as a bundle

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -19,6 +19,8 @@ tools:
     reference: ./bluesky
   slack:
     reference: ./slack
+  slack-bot:
+    reference: ./slack/tool-bot.gpt
   linkedin-publishing:
     reference: ./linkedin-publishing
   notion:

--- a/slack/tool-bot.gpt
+++ b/slack/tool-bot.gpt
@@ -1,0 +1,44 @@
+---
+Name: Slack Bot
+Description: Tools for interacting with Slack as an App
+Metadata: bundle: true
+Share Tools: Send Direct Message As Bot
+
+---
+Name: Send Direct Message As Bot
+Description: Send a direct message as a bot or an app in the Slack workspace
+Credential: ./credential/bot.gpt
+Share Tools: List Users As Bot, Search Users As Bot
+Param: userids: comma-separated list of user IDs to send the message to for a group message (example: USER1ID,USER2ID), or just one ID for an individual message
+Param: text: the text to send
+
+#!/usr/bin/env node ${GPTSCRIPT_TOOL_DIR}/index.js sendDM
+
+---
+Name: List Users As Bot
+Description: List all users in the Slack workspace as a bot
+Tools: github.com/gptscript-ai/datasets/filter
+Credential: ./credential/bot.gpt
+
+#!/usr/bin/env node ${GPTSCRIPT_TOOL_DIR}/index.js listUsers
+
+---
+Name: Search Users As Bot
+Description: Search for users in the Slack workspace as a bot
+Tools: github.com/gptscript-ai/datasets/filter
+Credential: ./credential/bot.gpt
+Param: query: the search query
+
+#!/usr/bin/env node ${GPTSCRIPT_TOOL_DIR}/index.js searchUsers
+
+---
+!metadata:*:icon
+/admin/assets/slack_icon_small.svg
+
+---
+!metadata:*:oauth
+slack
+
+---
+!metadata:*:supportsOAuthTokenPrompt
+true

--- a/slack/tool.gpt
+++ b/slack/tool.gpt
@@ -2,7 +2,7 @@
 Name: Slack
 Description: Tools for interacting with Slack
 Metadata: bundle: true
-Share Tools: List Channels, Search Channels, Get Channel History, Get Channel History by Time, Get Thread History From Link, Get Thread History, Search Messages, Send Message, Send Message in Thread, List Users, Search Users, Send DM, Send DM in Thread, Get Message Link, Get DM History, Get DM Thread History, Send Direct Message As Bot
+Share Tools: List Channels, Search Channels, Get Channel History, Get Channel History by Time, Get Thread History From Link, Get Thread History, Search Messages, Send Message, Send Message in Thread, List Users, Search Users, Send DM, Send DM in Thread, Get Message Link, Get DM History, Get DM Thread History
 
 ---
 Name: List Channels
@@ -184,16 +184,6 @@ Param: limit: the number of messages to return
 
 #!/usr/bin/env node ${GPTSCRIPT_TOOL_DIR}/index.js getDMThreadHistory
 
----
-Name: Send Direct Message As Bot
-Description: Send a direct message as a bot or an app in the Slack workspace
-Share Context: Slack Context
-Credential: ./credential/bot.gpt
-Share Tools: List Users, Search Users
-Param: userids: comma-separated list of user IDs to send the message to for a group message (example: USER1ID,USER2ID), or just one ID for an individual message
-Param: text: the text to send
-
-#!/usr/bin/env node ${GPTSCRIPT_TOOL_DIR}/index.js sendDM
 ---
 Name: User Context
 Description: Get information about the logged in user.


### PR DESCRIPTION
Make slack bot tools as a separate bundle tool by consuming bot token credential. This is so that we can avoid the case where we add more bot tools into our existing slack tool cause user to have prompt twice for different credentials requesting user vs bot token.

To minimize the scope of this PR, it is only adding functionality to send DM as Bot. We can extend more tools based on real use case later, like the tools we already have for slack