### PR TITLE
fix: database cred helpers: remove log

### DIFF
--- a/credential-stores/pkg/common/encryption.go
+++ b/credential-stores/pkg/common/encryption.go
@@ -25,7 +25,6 @@ func readEncryptionConfig(ctx context.Context) (*encryptionconfig.EncryptionConf
 	if _, err := os.Stat(encryptionConfigPath); err != nil {
 		if os.IsNotExist(err) {
 			if useDefault {
-				fmt.Println("WARNING: credentials will be stored unencrypted")
 				return nil, nil
 			}
 			return nil, fmt.Errorf("encryption config file does not exist: %w", err)


### PR DESCRIPTION
For some reason, this log message can cause the Obot server to hang when starting up.