### PR TITLE
feat: reuse documents/embeddings for files with the same sha256sum (+fix pgx bug)

### DIFF
--- a/knowledge/pkg/client/client.go
+++ b/knowledge/pkg/client/client.go
@@ -18,6 +18,7 @@ type SharedIngestionOpts struct {
 	IsDuplicateFuncName string
 	Metadata            map[string]string
 	ReuseEmbeddings     bool
+	ReuseFiles          bool
 }
 
 type IngestPathsOpts struct {

--- a/knowledge/pkg/client/standalone.go
+++ b/knowledge/pkg/client/standalone.go
@@ -113,6 +113,7 @@ func (c *StandaloneClient) IngestFromWorkspace(ctx context.Context, datasetID st
 		ExtraMetadata:       meta,
 		IngestionFlows:      opts.IngestionFlows,
 		ReuseEmbeddings:     opts.ReuseEmbeddings,
+		ReuseFiles:          opts.ReuseFiles,
 	}
 
 	_, err = c.Ingest(log.ToCtx(ctx, log.FromCtx(ctx).With("filepath", file).With("absolute_path", iopts.FileMetadata.AbsolutePath)), datasetID, finfo.Name, fileContent, iopts)
@@ -165,6 +166,7 @@ func (c *StandaloneClient) IngestPaths(ctx context.Context, datasetID string, op
 			IsDuplicateFuncName: opts.IsDuplicateFuncName,
 			ExtraMetadata:       extraMetadata,
 			ReuseEmbeddings:     opts.ReuseEmbeddings,
+			ReuseFiles:          opts.ReuseFiles,
 		}
 
 		if opts != nil {

--- a/knowledge/pkg/cmd/askdir.go
+++ b/knowledge/pkg/cmd/askdir.go
@@ -47,6 +47,7 @@ func (s *ClientAskDir) Run(cmd *cobra.Command, args []string) error {
 		SharedIngestionOpts: client.SharedIngestionOpts{
 			IsDuplicateFuncName: s.DeduplicationFuncName,
 			ReuseEmbeddings:     true,
+			ReuseFiles:          true,
 		},
 		IgnoreExtensions:     strings.Split(s.IgnoreExtensions, ","),
 		Concurrency:          s.Concurrency,

--- a/knowledge/pkg/cmd/ingest.go
+++ b/knowledge/pkg/cmd/ingest.go
@@ -103,6 +103,7 @@ func (s *ClientIngest) run(ctx context.Context, filePath string) error {
 			IsDuplicateFuncName: s.DeduplicationFuncName,
 			Metadata:            metadata,
 			ReuseEmbeddings:     true,
+			ReuseFiles:          true,
 		},
 		IgnoreExtensions:     strings.Split(s.IgnoreExtensions, ","),
 		Concurrency:          s.Concurrency,

--- a/knowledge/pkg/datastore/transformers/metadata.go
+++ b/knowledge/pkg/datastore/transformers/metadata.go
@@ -17,6 +17,9 @@ type ExtraMetadata struct {
 func (e *ExtraMetadata) Transform(_ context.Context, docs []vs.Document) ([]vs.Document, error) {
 	for i, doc := range docs {
 		metadata := doc.Metadata
+		if metadata == nil {
+			metadata = make(map[string]any)
+		}
 		for k, v := range e.Metadata {
 			metadata[k] = v
 		}

--- a/knowledge/pkg/index/index.go
+++ b/knowledge/pkg/index/index.go
@@ -26,6 +26,7 @@ type Index interface {
 	DeleteFile(ctx context.Context, datasetID, fileID string) error
 	FindFile(ctx context.Context, searchFile types.File) (*types.File, error)
 	FindFileByMetadata(ctx context.Context, dataset string, metadata types.FileMetadata, includeDocuments bool) (*types.File, error)
+	FindFilesByMetadata(ctx context.Context, dataset string, metadata types.FileMetadata, includeDocuments bool) ([]types.File, error)
 
 	// Advanced File Operations
 	PruneFiles(ctx context.Context, datasetID string, pathPrefix string, keep []string) ([]types.File, error)

--- a/knowledge/pkg/index/postgres/postgres.go
+++ b/knowledge/pkg/index/postgres/postgres.go
@@ -87,6 +87,10 @@ func (i *Index) FindFileByMetadata(ctx context.Context, dataset string, metadata
 	return i.DB.FindFileByMetadata(ctx, dataset, metadata, includeDocuments)
 }
 
+func (i *Index) FindFilesByMetadata(ctx context.Context, dataset string, metadata types.FileMetadata, includeDocuments bool) ([]types.File, error) {
+	return i.DB.FindFilesByMetadata(ctx, dataset, metadata, includeDocuments, false)
+}
+
 func (i *Index) GetDocumentByID(ctx context.Context, documentID string) (*types.Document, error) {
 	return i.DB.GetDocument(ctx, documentID)
 }

--- a/knowledge/pkg/index/sqlite/sqlite.go
+++ b/knowledge/pkg/index/sqlite/sqlite.go
@@ -171,6 +171,10 @@ func (i *Index) FindFileByMetadata(ctx context.Context, dataset string, metadata
 	return i.DB.FindFileByMetadata(ctx, dataset, metadata, includeDocuments)
 }
 
+func (i *Index) FindFilesByMetadata(ctx context.Context, dataset string, metadata types.FileMetadata, includeDocuments bool) ([]types.File, error) {
+	return i.DB.FindFilesByMetadata(ctx, dataset, metadata, includeDocuments, false)
+}
+
 func (i *Index) GetDocumentByID(ctx context.Context, documentID string) (*types.Document, error) {
 	return i.DB.GetDocument(ctx, documentID)
 }

--- a/knowledge/pkg/index/types/models.go
+++ b/knowledge/pkg/index/types/models.go
@@ -36,6 +36,7 @@ type FileMetadata struct {
 	AbsolutePath string    `json:"absolute_path"`
 	Size         int64     `json:"size"`
 	ModifiedAt   time.Time `json:"modified_at"`
+	Checksum     string    `json:"checksum"`
 }
 
 type Document struct {

--- a/knowledge/pkg/vectorstore/chromem/chromem.go
+++ b/knowledge/pkg/vectorstore/chromem/chromem.go
@@ -233,6 +233,26 @@ func (s *ChromemStore) ExportCollectionsToFile(ctx context.Context, path string,
 	return s.db.ExportToFile(path, false, "", collections...)
 }
 
+func (s *ChromemStore) GetDocument(ctx context.Context, documentID, collection string) (vs.Document, error) {
+	col := s.db.GetCollection(collection, s.embeddingFunc)
+	if col == nil {
+		return vs.Document{}, fmt.Errorf("%w: %q", errors.ErrCollectionNotFound, collection)
+	}
+
+	doc, err := col.GetByID(ctx, documentID)
+	if err != nil {
+		return vs.Document{}, err
+	}
+
+	return vs.Document{
+		ID:        doc.ID,
+		Metadata:  convertStringMapToAnyMap(doc.Metadata),
+		Content:   doc.Content,
+		Embedding: doc.Embedding,
+	}, nil
+
+}
+
 func (s *ChromemStore) GetDocuments(ctx context.Context, collection string, where map[string]string, whereDocument []chromem.WhereDocument) ([]vs.Document, error) {
 	col := s.db.GetCollection(collection, s.embeddingFunc)
 	if col == nil {
@@ -247,9 +267,10 @@ func (s *ChromemStore) GetDocuments(ctx context.Context, collection string, wher
 	var docs []vs.Document
 	for _, doc := range cdocs {
 		docs = append(docs, vs.Document{
-			ID:       doc.ID,
-			Metadata: convertStringMapToAnyMap(doc.Metadata),
-			Content:  doc.Content,
+			ID:        doc.ID,
+			Metadata:  convertStringMapToAnyMap(doc.Metadata),
+			Content:   doc.Content,
+			Embedding: doc.Embedding,
 		})
 	}
 

--- a/knowledge/pkg/vectorstore/pgvector/pgvector.go
+++ b/knowledge/pkg/vectorstore/pgvector/pgvector.go
@@ -354,7 +354,6 @@ func (v VectorStore) AddDocuments(ctx context.Context, docs []vs.Document, colle
 	slog.Debug("Sending batch to pgvector", "store", "pgvector", "batchSize", b.Len())
 
 	results := v.conn.SendBatch(ctx, b)
-	defer results.Close()
 	for _, d := range docs {
 		_, err := results.Exec()
 		if err != nil {

--- a/knowledge/pkg/vectorstore/pgvector/pgvector.go
+++ b/knowledge/pkg/vectorstore/pgvector/pgvector.go
@@ -307,13 +307,12 @@ func (v VectorStore) AddDocuments(ctx context.Context, docs []vs.Document, colle
 		VALUES($1, $2, $3, $4, $5)`, v.embeddingTableName)
 
 	var wg sync.WaitGroup
+	qqLock := sync.Mutex{} // lock for the pgx batch queue
 	semaphore := make(chan struct{}, v.embeddingConcurrency)
+	wg.Add(len(docs))
 	for docIdx, doc := range docs {
-		id := uuid.New().String()
-		ids[docIdx] = id
-		doc.ID = id
+		ids[docIdx] = doc.ID
 
-		wg.Add(1)
 		go func(doc vs.Document) {
 			defer wg.Done()
 
@@ -328,17 +327,20 @@ func (v VectorStore) AddDocuments(ctx context.Context, docs []vs.Document, colle
 
 			var vec []float32
 			if len(doc.Embedding) > 0 {
-				slog.Debug("Using provided embedding", "documentID", doc.ID, "store", "pgvector")
 				vec = doc.Embedding
 			} else {
 				vec, err = v.embeddingFunc(ctx, doc.Content)
 				if err != nil {
+					slog.Error("failed to embed document", "documentID", doc.ID, "error", err)
 					setSharedErr(fmt.Errorf("failed to embed document %s: %w", doc.ID, err))
 					return
 				}
 			}
 
+			qqLock.Lock()
 			b.Queue(sql, doc.ID, []byte(doc.Content), pgvector.NewVector(vec), doc.Metadata, cid)
+			qqLock.Unlock()
+			slog.Debug("Adding document to pgvector", "documentID", doc.ID, "collection", collection, "queueSize", b.Len())
 		}(doc)
 
 		docs[docIdx] = doc
@@ -349,7 +351,18 @@ func (v VectorStore) AddDocuments(ctx context.Context, docs []vs.Document, colle
 		return nil, sharedErr
 	}
 
-	return ids, v.conn.SendBatch(ctx, b).Close()
+	slog.Debug("Sending batch to pgvector", "store", "pgvector", "batchSize", b.Len())
+
+	results := v.conn.SendBatch(ctx, b)
+	defer results.Close()
+	for _, d := range docs {
+		_, err := results.Exec()
+		if err != nil {
+			slog.Error("failed to insert document in pgvector", "documentID", d.ID, "error", err)
+		}
+	}
+
+	return ids, results.Close()
 }
 
 /*
@@ -478,6 +491,25 @@ func (v VectorStore) RemoveDocument(ctx context.Context, documentID string, coll
 
 	_, err = v.conn.Exec(ctx, fmt.Sprintf(`DELETE FROM %s WHERE uuid = $1 AND collection_id = $2`, v.embeddingTableName), documentID, cid)
 	return err
+}
+
+func (v VectorStore) GetDocument(ctx context.Context, documentID, collection string) (vs.Document, error) {
+	cid, err := v.getCollectionUUID(ctx, collection)
+	if err != nil {
+		return vs.Document{}, err
+	}
+
+	var doc vs.Document
+	var content []byte
+	var vec pgvector.Vector
+	err = v.conn.QueryRow(ctx, fmt.Sprintf(`SELECT document, cmetadata, embedding FROM %s WHERE uuid = $1 AND collection_id = $2`, v.embeddingTableName), documentID, cid).Scan(&content, &doc.Metadata, &vec)
+	if err != nil {
+		return vs.Document{}, err
+	}
+	doc.ID = documentID
+	doc.Content = string(content)
+	doc.Embedding = vec.Slice()
+	return doc, nil
 }
 
 func (v VectorStore) GetDocuments(ctx context.Context, collection string, where map[string]string, whereDocument []cg.WhereDocument) ([]vs.Document, error) {

--- a/knowledge/pkg/vectorstore/sqlite-vec/helper.go
+++ b/knowledge/pkg/vectorstore/sqlite-vec/helper.go
@@ -1,0 +1,16 @@
+package sqlite_vec
+
+import (
+	"bytes"
+	"encoding/binary"
+)
+
+func DeserializeFloat32(data []byte) ([]float32, error) {
+	buf := bytes.NewReader(data)
+	var vector []float32
+	err := binary.Read(buf, binary.LittleEndian, &vector)
+	if err != nil {
+		return nil, err
+	}
+	return vector, nil
+}

--- a/knowledge/pkg/vectorstore/sqlite-vec/sqlite-vec.go
+++ b/knowledge/pkg/vectorstore/sqlite-vec/sqlite-vec.go
@@ -342,7 +342,7 @@ func (v *VectorStore) GetDocument(ctx context.Context, documentID, collection st
 		SELECT embedding
 		FROM [%s_vec]
 		WHERE document_id = ?;
-		`), documentID).Row().Scan(&emb)
+		`, collection), documentID).Row().Scan(&emb)
 	if err != nil {
 		return vs.Document{}, fmt.Errorf("failed to query embeddings: %w", err)
 	}

--- a/knowledge/pkg/vectorstore/sqlite-vec/sqlite-vec.go
+++ b/knowledge/pkg/vectorstore/sqlite-vec/sqlite-vec.go
@@ -317,6 +317,45 @@ func (v *VectorStore) RemoveDocument(ctx context.Context, documentID string, col
 	return nil
 }
 
+func (v *VectorStore) GetDocument(ctx context.Context, documentID, collection string) (vs.Document, error) {
+	var doc vs.Document
+	var metadata string
+
+	err := v.db.Raw(fmt.Sprintf(`
+		SELECT content, metadata 
+		FROM [%s]
+		WHERE id = ? AND collection_id = ?;
+	`, v.embeddingsTableName), documentID, collection).Row().Scan(&doc.Content, &metadata)
+	if err != nil {
+		return vs.Document{}, fmt.Errorf("failed to query document: %w", err)
+	}
+
+	if err := json.Unmarshal([]byte(metadata), &doc.Metadata); err != nil {
+		return vs.Document{}, fmt.Errorf("failed to parse metadata for document %s: %w", documentID, err)
+	}
+
+	doc.ID = documentID
+
+	// Get embeddings
+	var emb []byte
+	err = v.db.Raw(fmt.Sprintf(`
+		SELECT embedding
+		FROM [%s_vec]
+		WHERE document_id = ?;
+		`), documentID).Row().Scan(&emb)
+	if err != nil {
+		return vs.Document{}, fmt.Errorf("failed to query embeddings: %w", err)
+	}
+
+	embedding, err := DeserializeFloat32(emb)
+	if err != nil {
+		return vs.Document{}, fmt.Errorf("failed to deserialize embeddings: %w", err)
+	}
+	doc.Embedding = embedding
+
+	return doc, nil
+}
+
 func (v *VectorStore) GetDocuments(_ context.Context, collection string, where map[string]string, whereDocument []cg.WhereDocument) ([]vs.Document, error) {
 	var docs []vs.Document
 

--- a/knowledge/pkg/vectorstore/vectorstores.go
+++ b/knowledge/pkg/vectorstore/vectorstores.go
@@ -22,6 +22,7 @@ type VectorStore interface {
 	RemoveCollection(ctx context.Context, collection string) error
 	RemoveDocument(ctx context.Context, documentID string, collection string, where map[string]string, whereDocument []cg.WhereDocument) error
 	GetDocuments(ctx context.Context, collection string, where map[string]string, whereDocument []cg.WhereDocument) ([]types.Document, error)
+	GetDocument(ctx context.Context, documentID string, collection string) (types.Document, error)
 
 	ImportCollectionsFromFile(ctx context.Context, path string, collections ...string) error
 	ExportCollectionsToFile(ctx context.Context, path string, collections ...string) error


### PR DESCRIPTION
- calculate sha256sum for the content of each ingested file and record it in the DB
- when ingesting a file, check if there's a file with the same checksum in the DB
- if yes and the embeddingModel (config on the owning dataset) matches the incoming one, then fetch the file's documents and their embeddings to re-use for the incoming file

NOTE: This is fine in the Obot setup, as we're using a static flow config for Obot, but if someone is playing with the flow config to test different settings, this may lead to reusing documents from file that were ingested with an old config - we can add checks for that as a follow-up.

Also, I figured that there's a race condition in the pgvector implementation, because appending to the pgx batch queue is not lock protected and I saw some cases, where documents got lost due to this. This is fixed now.

Issue: https://github.com/obot-platform/obot/issues/1803