### PR TITLE
enhance: github: add tool to get job logs

### DIFF
--- a/github/index.js
+++ b/github/index.js
@@ -20,6 +20,7 @@ import {
     addIssueLabels,
     removeIssueLabels,
     getUser,
+    getJobLogs,
 } from './src/tools.js';
 
 if (process.argv.length !== 3) {
@@ -98,6 +99,9 @@ try {
             break;
         case 'removeIssueLabels':
             await removeIssueLabels(octokit, process.env.OWNER, process.env.REPO, process.env.ISSUENUMBER, process.env.LABELS);
+            break;
+        case 'getJobLogs':
+            await getJobLogs(octokit, process.env.OWNER, process.env.REPO, process.env.JOBID);
             break;
         default:
             throw new Error(`Unknown command: ${command}`);

--- a/github/src/tools.js
+++ b/github/src/tools.js
@@ -345,3 +345,12 @@ export async function removeIssueLabels(octokit, owner, repo, issueNumber, label
 export async function getUser(octokit) {
     await octokit.users.getAuthenticated();
 }
+
+export async function getJobLogs(octokit, owner, repo, jobId) {
+    const response = await octokit.request('GET /repos/{owner}/{repo}/actions/jobs/{job_id}/logs', {
+        owner,
+        repo,
+        job_id: jobId
+    });
+    console.log(response.data);
+}

--- a/github/tool.gpt
+++ b/github/tool.gpt
@@ -2,7 +2,7 @@
 Name: GitHub
 Description: Tools for interacting with GitHub
 Metadata: bundle: true
-Share Tools: Search Issues and PRs, Get Issue, Create Issue, Modify Issue, Close Issue, List Issue Comments, Add Comment to Issue, Get PR, Create PR, Modify PR, Close PR, List PR Comments, Add Comment to PR, List Repos, Get Star Count, List Assigned Issues, List PRs for Review, Add Issue Labels, Remove Issue Labels
+Share Tools: Search Issues and PRs, Get Issue, Create Issue, Modify Issue, Close Issue, List Issue Comments, Add Comment to Issue, Get PR, Create PR, Modify PR, Close PR, List PR Comments, Add Comment to PR, List Repos, Get Star Count, List Assigned Issues, List PRs for Review, Add Issue Labels, Remove Issue Labels, Get Job Logs
 
 ---
 Name: Search Issues and PRs
@@ -239,6 +239,17 @@ Param: issueNumber: the number of the issue or pull request to remove labels fro
 Param: labels: (optional) comma-separated list of labels to remove. If not provided, all labels will be removed.
 
 #!/usr/bin/env node ${GPTSCRIPT_TOOL_DIR}/index.js removeIssueLabels
+
+---
+Name: Get Job Logs
+Description: Get the logs for a specific GitHub Actions job
+Credential: ./credential
+Share Context: GitHub Context
+Param: owner: the owner of the repository
+Param: repo: the name of the repository
+Param: jobId: the ID of the job to get logs for
+
+#!/usr/bin/env node ${GPTSCRIPT_TOOL_DIR}/index.js getJobLogs
 
 ---
 Name: GitHub Context


### PR DESCRIPTION
This will be needed for the GitHub CI failure webhook obot.