### PR TITLE
Enhance: Add more slack bot tools

### DIFF
--- a/slack/credential/bot.gpt
+++ b/slack/credential/bot.gpt
@@ -13,9 +13,20 @@ Tools: ../../oauth2
 		"integration": "slack",
 		"token": "SLACK_TOKEN",
 		"scope": [
+			"channels:history",
+			"groups:history",
+			"im:history",
+			"mpim:history",
+			"channels:read",
+			"files:read",
+			"im:read",
+			"team:read",
+			"users:read",
+			"groups:read",
 			"chat:write",
-			"im:write",
-			"users:read"
+			"groups:write",
+			"mpim:write",
+			"im:write"
 		]
 	},
 	"promptInfo": {

--- a/slack/tool-bot.gpt
+++ b/slack/tool-bot.gpt
@@ -2,7 +2,130 @@
 Name: Slack Bot
 Description: Tools for interacting with Slack as an App
 Metadata: bundle: true
-Share Tools: Send Direct Message As Bot
+Share Tools: Send Direct Message As Bot, List Channels As Bot, Search Channels As Bot, Get Channel History As Bot, Get Channel History By Time As Bot, Get Thread History From Link As Bot, Get Thread History As Bot, Send Message As Bot, Send Message in Thread As Bot, List Users As Bot, Search Users As Bot, Send DM in Thread As Bot, Send Direct Message As Bot, Get Message Link As Bot, Get DM History As Bot, Get DM Thread History As Bot
+
+---
+Name: List Channels As Bot
+Description: List all channels in the Slack workspace as a bot. Returns the name and ID for each channel
+Share Context: Slack Context
+Tools: github.com/gptscript-ai/datasets/filter
+Credential: ./credential/bot.gpt
+
+#!/usr/bin/env node ${GPTSCRIPT_TOOL_DIR}/index.js listChannels
+
+---
+Name: Search Channels As Bot
+Description: Search for channels in the Slack workspace as a bot
+Share Context: Slack Context
+Tools: github.com/gptscript-ai/datasets/filter
+Credential: ./credential/bot.gpt
+Param: query: the search query
+
+#!/usr/bin/env node ${GPTSCRIPT_TOOL_DIR}/index.js searchChannels
+
+---
+Name: Get Channel History As Bot
+Description: Get the chat history for a channel in the Slack workspace as a bot
+Share Context: Slack Context
+Tools: github.com/gptscript-ai/datasets/filter
+Credential: ./credential/bot.gpt
+Share Tools: List Channels As Bot, Search Channels As Bot
+Param: channelid: the ID of the channel to get the history for
+Param: limit: the number of messages to return - recommend starting with 10 and increasing if necessary
+
+#!/usr/bin/env node ${GPTSCRIPT_TOOL_DIR}/index.js getChannelHistory
+
+---
+Name: Get Channel History by Time As Bot
+Description: Get the chat history for a channel in the Slack workspace within a specific time range as a bot
+Share Context: Slack Context
+Tools: github.com/gptscript-ai/datasets/filter
+Credential: ./credential/bot.gpt
+Share Tools: List Channels As Bot, Search Channels As Bot
+Param: channelid: the ID of the channel to get the history for
+Param: limit: the maximum number of messages to return - recommend starting with 10 and increasing if necessary
+Param: start: the start time in RFC 3339 format
+Param: end: the end time in RFC 3339 format
+
+#!/usr/bin/env node ${GPTSCRIPT_TOOL_DIR}/index.js getChannelHistoryByTime
+
+---
+Name: Get Thread History From Link As Bot
+Description: Get the chat history for a particular thread from a Slack message link as a bot
+Share Context: Slack Context
+Tools: github.com/gptscript-ai/datasets/filter
+Credential: ./credential/bot.gpt
+Param: messageLink: the link to the first Slack message in the thread (example "https://team.slack.com/archives/CHANNEL_ID/p1234567890123456")
+Param: limit: the number of messages to return
+
+#!/usr/bin/env node ${GPTSCRIPT_TOOL_DIR}/index.js getThreadHistoryFromLink
+
+---
+Name: Get Thread History As Bot
+Description: Get the chat history for a particular thread as a bot
+Share Context: Slack Context
+Tools: github.com/gptscript-ai/datasets/filter
+Credential: ./credential/bot.gpt
+Share Tools: List Channels As Bot, Get Channel History As Bot
+Param: channelid: the ID of the channel containing the thread
+Param: threadid: the ID of the thread to get the history for
+Param: limit: the number of messages to return
+
+#!/usr/bin/env node ${GPTSCRIPT_TOOL_DIR}/index.js getThreadHistory
+
+---
+Name: Send Message As Bot
+Description: Send a message to a channel in the Slack workspace as a bot
+Share Context: Slack Context
+Credential: ./credential/bot.gpt
+Share Tools: List Channels As Bot, Search Channels As Bot
+Param: channelid: the ID of the channel to send the message to
+Param: text: the text to send
+
+#!/usr/bin/env node ${GPTSCRIPT_TOOL_DIR}/index.js sendMessage
+
+---
+Name: Send Message in Thread As Bot
+Description: Send a message in a thread in the Slack workspace as a bot
+Share Context: Slack Context
+Credential: ./credential/bot.gpt
+Share Tools: List Channels As Bot, Search Channels As Bot, Get Channel History As Bot
+Param: channelid: the ID of the channel containing the thread
+Param: threadid: the ID of the thread to send the message to
+Param: text: the text to send
+
+#!/usr/bin/env node ${GPTSCRIPT_TOOL_DIR}/index.js sendMessageInThread
+
+---
+Name: List Users As Bot
+Description: List all users in the Slack workspace as a bot
+Share Context: Slack Context
+Tools: github.com/gptscript-ai/datasets/filter
+Credential: ./credential/bot.gpt
+
+#!/usr/bin/env node ${GPTSCRIPT_TOOL_DIR}/index.js listUsers
+
+---
+Name: Search Users As Bot
+Description: Search for users in the Slack workspace as a bot
+Share Context: Slack Context
+Tools: github.com/gptscript-ai/datasets/filter
+Credential: ./credential/bot.gpt
+Param: query: the search query
+
+#!/usr/bin/env node ${GPTSCRIPT_TOOL_DIR}/index.js searchUsers
+
+---
+Name: Send DM in Thread As Bot
+Description: Send a message in a thread in a direct message conversation as a bot
+Share Context: Slack Context
+Credential: ./credential/bot.gpt
+Share Tools: List Users As Bot, Search Users As Bot, Get DM History As Bot
+Param: userids: comma-separated list of user IDs for the conversation (example: USER1ID,USER2ID), or just one ID for an individual conversation
+Param: threadid: the ID of the thread to send the message to
+Param: text: the text to send
+
+#!/usr/bin/env node ${GPTSCRIPT_TOOL_DIR}/index.js sendDMInThread
 
 ---
 Name: Send Direct Message As Bot
@@ -15,21 +138,88 @@ Param: text: the text to send
 #!/usr/bin/env node ${GPTSCRIPT_TOOL_DIR}/index.js sendDM
 
 ---
-Name: List Users As Bot
-Description: List all users in the Slack workspace as a bot
-Tools: github.com/gptscript-ai/datasets/filter
+Name: Get Message Link As Bot
+Description: Get the permalink for a message as a bot
+Share Context: Slack Context
 Credential: ./credential/bot.gpt
+Share Tools: List Channels As Bot, Search Channels As Bot
+Param: channelid: the ID of the channel containing the message
+Param: messageid: the ID of the message
 
-#!/usr/bin/env node ${GPTSCRIPT_TOOL_DIR}/index.js listUsers
+#!/usr/bin/env node ${GPTSCRIPT_TOOL_DIR}/index.js getMessageLink
 
 ---
-Name: Search Users As Bot
-Description: Search for users in the Slack workspace as a bot
+Name: Get DM History As Bot
+Description: Get the chat history for a direct message conversation as a bot
+Share Context: Slack Context
 Tools: github.com/gptscript-ai/datasets/filter
 Credential: ./credential/bot.gpt
-Param: query: the search query
+Share Tools: List Users As Bot, Search Users As Bot
+Param: userids: comma-separated list of user IDs for the conversation (example: USER1ID,USER2ID), or just one ID for an individual conversation
+Param: limit: the number of messages to return
 
-#!/usr/bin/env node ${GPTSCRIPT_TOOL_DIR}/index.js searchUsers
+#!/usr/bin/env node ${GPTSCRIPT_TOOL_DIR}/index.js getDMHistory
+
+---
+Name: Get DM Thread History As Bot
+Description: Get the chat history for a thread in a direct message conversation as a bot
+Share Context: Slack Context
+Tools: github.com/gptscript-ai/datasets/filter
+Credential: ./credential/bot.gpt
+Share Tools: List Users As Bot, Search Users As Bot, Get DM History As Bot
+Param: userids: comma-separated list of user IDs for the conversation (example: USER1ID,USER2ID), or just one ID for an individual conversation
+Param: threadid: the ID of the thread to get the history for
+Param: limit: the number of messages to return
+
+#!/usr/bin/env node ${GPTSCRIPT_TOOL_DIR}/index.js getDMThreadHistory
+
+---
+Name: User Context
+Description: Get information about the logged in bot user
+Credential: ./credential/bot.gpt
+
+#!/usr/bin/env node ${GPTSCRIPT_TOOL_DIR}/index.js userContext
+
+---
+Name: Slack Context
+Type: context
+Share Tools: User Context
+
+#!sys.echo
+
+## Instructions for using Slack tools
+
+You have access to a set of tools to interact with a Slack workspace as a bot.
+
+Wait to call the User Context tool until the user asks you something about Slack. Always call this tool before calling any other Slack tools.
+
+When mentioning a user in a message you create, use the format <@USERID>, including the angle brackets.
+The user ID can be obtained from the List Users or Search Users tool.
+
+Do not provide channel, thread, or message IDs in the output, as these are not helpful for the user.
+When you use the search-messages tool, you can use normal Slack search filters. If you filter by user, use the full username, which can be obtained from the search-users or list-users tools.
+
+Display all dates and times in the user's preferred timezone. When the user gives values for dates and times, assume they are in the user's preferred timezone unless otherwise specified by the user.
+
+Use the following guidelines when constructing `query` arguments for the search-messages tool:
+- `*` (Wildcard): Matches any number of characters in a term. Example: `dev*` matches "developer", "development", etc.
+- `-` (Negation): Excludes a term or modifier by prepending a dash. Example: `-in:#random` excludes results from `#random`, `-update` excludes messages containing "update".
+- Boolean Operators: Use `AND`, `OR`, and `NOT` to refine searches.
+  Examples:
+  - `project AND update` finds messages containing both "project" and "update".
+  - `project OR update` finds messages containing either "project" or "update".
+  - `project NOT update` finds messages containing "project" but excluding "update".
+- Combining multiple modifiers: Separate each modifier and search term with spaces (order does not matter). Example: `update from:@alice in:#general after:2025-01-01 -in:#random`
+
+The following search modifiers can be used in search-messages `query` arguments:
+- `after:<date>`: Matches messages sent after the specified date (exclusive, so excludes messages from the given date). Must be in `YYYY-MM-DD` format (no time/timezone). Example: `after:2025-01-01`
+- `before:<date>`: Matches messages sent before the specified date (exclusive, so excludes messages from the given date). Example: `before:2025-01-01`
+- `with:<user>`: Matches messages from threads/DMs that include the specified user. Example: `with:@bob`
+- `from:<user>`: Matches messages sent by the specified user. Example: `from:@alice`
+- `in:<channel>`: Matches messages from the specified channel. Example: `in:#general`
+- `is:<type>`: Matches messages of the specified type. Valid types are `dm`, `thread`. Example: `is:thread`
+
+## End of instructions for using Slack tools
 
 ---
 !metadata:*:icon


### PR DESCRIPTION
This PR adds more slack bot tools so that the bot can do more things like send message to channels, list channels. It will also request more scopes.

Search message from slack tool is not added because it is not supported by the bot.