### PR TITLE
enhance: File Summarizer Tool to support pdf/pptx/docx

### DIFF
--- a/file-summarizer/file_reader.py
+++ b/file-summarizer/file_reader.py
@@ -3,6 +3,7 @@ from helper import setup_logger, get_openai_client
 from summarize import DocumentSummarizer, MODEL, TIKTOKEN_MODEL, MAX_CHUNK_TOKENS, MAX_WORKERS
 import os
 import tiktoken
+import asyncio
 
 logger = setup_logger(__name__)
 
@@ -28,12 +29,15 @@ async def main():
         try:
             final_summary = summarizer.summarize(file_content)
         except Exception as e:
+            logger.error(f"Summarization failed: {e}")
             raise Exception(f"ERROR: Summarization failed: {e}")
         
-        response_str = f"Uploaded file {input_file} contains {len(tokens)} tokens.\n\n"
-        response_str += f"Summary of the file content:\n\n{final_summary}"
+        response_str = f"The uploaded file {input_file} contains too many tokens ({len(tokens)}), here is the summary of the file content:\n\n{final_summary}"
         print(response_str)
         return response_str
     else: # if the file has less than TOKEN_THRESHOLD tokens, directly return the file content
         print(file_content)
         return file_content
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/file-summarizer/file_reader.py
+++ b/file-summarizer/file_reader.py
@@ -1,0 +1,39 @@
+from load_text import load_text_from_file
+from helper import setup_logger, get_openai_client
+from summarize import DocumentSummarizer, MODEL, TIKTOKEN_MODEL, MAX_CHUNK_TOKENS, MAX_WORKERS
+import os
+import tiktoken
+
+logger = setup_logger(__name__)
+
+TIKTOKEN_MODEL = "gpt-4o"
+enc = tiktoken.encoding_for_model(TIKTOKEN_MODEL)
+TOKEN_THRESHOLD = 10000
+
+async def main():
+    input_file = os.getenv("INPUT_FILE", "")
+    if not input_file:
+        raise ValueError("Error: INPUT_FILE environment variable is not set")
+
+    file_content = await load_text_from_file(input_file)
+    tokens = enc.encode(file_content)
+    
+    if len(tokens) > TOKEN_THRESHOLD: # if the file has too many tokens, summarize it
+        summarizer = DocumentSummarizer(
+            get_openai_client(),
+            model=MODEL,
+            max_chunk_tokens=MAX_CHUNK_TOKENS,
+            max_workers=MAX_WORKERS,
+        )
+        try:
+            final_summary = summarizer.summarize(file_content)
+        except Exception as e:
+            raise Exception(f"ERROR: Summarization failed: {e}")
+        
+        response_str = f"Uploaded file {input_file} contains {len(tokens)} tokens.\n\n"
+        response_str += f"Summary of the file content:\n\n{final_summary}"
+        print(response_str)
+        return response_str
+    else: # if the file has less than TOKEN_THRESHOLD tokens, directly return the file content
+        print(file_content)
+        return file_content

--- a/file-summarizer/load_text.py
+++ b/file-summarizer/load_text.py
@@ -3,8 +3,9 @@ import struct
 import fitz  # PyMuPDF
 import docx
 from pptx import Presentation
-from helper import load_from_gptscript_workspace, save_to_gptscript_workspace
+from helper import load_from_gptscript_workspace, setup_logger
 
+logger = setup_logger(__name__)
 
 def extract_text_from_pdf(pdf_bytes: bytes) -> str:
     """Extracts text from a PDF file given as bytes."""
@@ -53,6 +54,7 @@ async def load_text_from_file(file_path: str) -> str:
     try:
         file_content = await load_from_gptscript_workspace(file_path)
     except Exception as e:
+        logger.error(f"Failed to load file from GPTScript workspace file {file_path}, Error: {e}")
         raise ValueError(
             f"Failed to load file from GPTScript workspace file {file_path}, Error: {e}"
         )

--- a/file-summarizer/load_text.py
+++ b/file-summarizer/load_text.py
@@ -1,0 +1,71 @@
+import io
+import struct
+import fitz  # PyMuPDF
+import docx
+from pptx import Presentation
+from helper import load_from_gptscript_workspace, save_to_gptscript_workspace
+
+
+def extract_text_from_pdf(pdf_bytes: bytes) -> str:
+    """Extracts text from a PDF file given as bytes."""
+    pdf_stream = io.BytesIO(pdf_bytes)
+    doc = fitz.open(stream=pdf_stream, filetype="pdf")
+    
+    text = []
+    for page in doc:
+        text.append(page.get_text("text"))
+    
+    return "\n".join(text)
+
+def extract_text_from_docx(docx_bytes: bytes) -> str:
+    """Extracts text from a Word (.docx) file given as bytes."""
+    doc_stream = io.BytesIO(docx_bytes)
+    doc = docx.Document(doc_stream)
+    
+    return "\n".join([para.text for para in doc.paragraphs])
+
+def extract_text_from_pptx(pptx_bytes: bytes) -> str:
+    """Extracts text from a PowerPoint (.pptx) file given as bytes."""
+    ppt_stream = io.BytesIO(pptx_bytes)
+    prs = Presentation(ppt_stream)
+    
+    text = []
+    for slide in prs.slides:
+        for shape in slide.shapes:
+            if hasattr(shape, "text"):
+                text.append(shape.text)
+    
+    return "\n".join(text)
+
+
+
+SUPPORTED_TEXT_FILE_TYPES = (".md", ".txt", ".markdown", ".text", ".mdx", ".mdtxt", ".mdtxtx")
+SUPPORTED_DOC_FILE_TYPES = (".docx", ".pdf", ".pptx")
+ALL_SUPPORTED_FILE_TYPES = SUPPORTED_TEXT_FILE_TYPES + SUPPORTED_DOC_FILE_TYPES
+
+async def load_text_from_file(file_path: str) -> str:
+    
+    if not file_path.endswith(ALL_SUPPORTED_FILE_TYPES):
+        raise ValueError(
+            f"Error: the input file must end with one of the following file types: {ALL_SUPPORTED_FILE_TYPES}, other file types are not supported yet."
+        )
+
+    try:
+        file_content = await load_from_gptscript_workspace(file_path)
+    except Exception as e:
+        raise ValueError(
+            f"Failed to load file from GPTScript workspace file {file_path}, Error: {e}"
+        )
+    
+    if file_path.endswith(SUPPORTED_TEXT_FILE_TYPES):
+        file_content = file_content.decode("utf-8")
+        return file_content
+    elif file_path.endswith(SUPPORTED_DOC_FILE_TYPES):
+        if file_path.endswith(".pdf"):
+            return extract_text_from_pdf(file_content)
+        elif file_path.endswith(".docx"):
+            return extract_text_from_docx(file_content)
+        elif file_path.endswith(".pptx"):
+            return extract_text_from_pptx(file_content)
+    else:
+        raise ValueError(f"Unsupported file type: {file_path}")

--- a/file-summarizer/requirements.txt
+++ b/file-summarizer/requirements.txt
@@ -1,3 +1,6 @@
 openai
 tiktoken
 git+https://github.com/gptscript-ai/py-gptscript.git@0cebee3afa51b8c56006e479a990c262bd693ba6#egg=gptscript
+python-docx
+pymupdf
+python-pptx

--- a/file-summarizer/summarize.py
+++ b/file-summarizer/summarize.py
@@ -295,7 +295,7 @@ async def main():
         if output_file == "":
             directory, file_name = os.path.split(input_file)
             name, ext = os.path.splitext(file_name)
-            summary_file_name = f"{name}_summary{ext}"
+            summary_file_name = f"{name}_summary.md"
             output_file = os.path.join(directory, summary_file_name)
 
         try:

--- a/file-summarizer/tool.gpt
+++ b/file-summarizer/tool.gpt
@@ -1,10 +1,19 @@
+---
 Name: File Summarizer
 Description: This tool summarizes the input file in the workspace, returns a text summary of the file content, either write to a file in the workspace or print to the console.
 Credential: sys.model.provider.credential
-Params: input_file: (Required) Name of the file in the workspace to summarize. Only .txt and .md files are supported, for any other file types, simply say it's not supported yet.
+Params: input_file: (Required) Name of the file in the workspace to summarize. Supported formats: [.md", ".txt", ".markdown", ".text", ".mdx", ".mdtxt", ".mdtxtx", ".docx", ".pdf", ".pptx"]. For any other file types, simply say it's not supported yet.
 Params: output_file: (Optional) Name of the file to save the summary, default to empty string. If not provided, a summary file will be created in the same directory as the input file. To print to the console, set this to "NONE".
 
 #!/usr/bin/env python3 ${GPTSCRIPT_TOOL_DIR}/summarize.py
+
+---
+Name: File Reader
+Description: This tool reads the input file in the workspace, returns the file content and print to the console.
+Credential: sys.model.provider.credential
+Params: input_file: (Required) Name of the file in the workspace to summarize. Supported formats: [.md", ".txt", ".markdown", ".text", ".mdx", ".mdtxt", ".mdtxtx", ".docx", ".pdf", ".pptx"]. For any other file types, simply say it's not supported yet.
+
+#!/usr/bin/env python3 ${GPTSCRIPT_TOOL_DIR}/file_reader.py
 
 ---
 !metadata:*:category

--- a/file-summarizer/tool.gpt
+++ b/file-summarizer/tool.gpt
@@ -1,19 +1,10 @@
----
 Name: File Summarizer
 Description: This tool summarizes the input file in the workspace, returns a text summary of the file content, either write to a file in the workspace or print to the console.
 Credential: sys.model.provider.credential
-Params: input_file: (Required) Name of the file in the workspace to summarize. Supported formats: [.md", ".txt", ".markdown", ".text", ".mdx", ".mdtxt", ".mdtxtx", ".docx", ".pdf", ".pptx"]. For any other file types, simply say it's not supported yet.
+Params: input_file: (Required) Name of the file in the workspace to summarize. Supported formats: [.md, .txt, .markdown, .text, .mdx, .mdtxt, .mdtxtx, .docx, .pdf, .pptx]. For any other file types, simply say it's not supported yet.
 Params: output_file: (Optional) Name of the file to save the summary, default to empty string. If not provided, a summary file will be created in the same directory as the input file. To print to the console, set this to "NONE".
 
 #!/usr/bin/env python3 ${GPTSCRIPT_TOOL_DIR}/summarize.py
-
----
-Name: File Reader
-Description: This tool reads the input file in the workspace, returns the file content and print to the console.
-Credential: sys.model.provider.credential
-Params: input_file: (Required) Name of the file in the workspace to summarize. Supported formats: [.md", ".txt", ".markdown", ".text", ".mdx", ".mdtxt", ".mdtxtx", ".docx", ".pdf", ".pptx"]. For any other file types, simply say it's not supported yet.
-
-#!/usr/bin/env python3 ${GPTSCRIPT_TOOL_DIR}/file_reader.py
 
 ---
 !metadata:*:category


### PR DESCRIPTION
https://github.com/obot-platform/obot/issues/1405
This PR:
- Add support for pdf/pptx/docx files:
    - use `mupdf` to parse pdf
    - use `python-docx` for docx (this won't support .doc)
    - use `python-pptx` for pptx (not .ppt)
- add logger for debugging. 
- updated prompts

**Note:**
- PDF: Our `Knowledge Tool` includes an advanced PDF parser. However, since we don’t plan to create APIs from the existing Go-based implementation, we can integrate [gptparse](https://github.com/gptscript-ai/gptparse/tree/main), which requires `poppler` installed in the system. I believe the `Knowledge Tool` is already built on top of it.

