### PR TITLE
chore: make API Key param optional for vLLM

### DIFF
--- a/vllm-model-provider/tool.gpt
+++ b/vllm-model-provider/tool.gpt
@@ -1,6 +1,6 @@
 Name: vLLM
 Description: Model Provider for vLLM
-Metadata: envVars: OBOT_VLLM_MODEL_PROVIDER_ENDPOINT,OBOT_VLLM_MODEL_PROVIDER_API_KEY
+Metadata: envVars: OBOT_VLLM_MODEL_PROVIDER_ENDPOINT
 Model Provider: true
 Credential: ../placeholder-credential as vllm-model-provider with OBOT_VLLM_MODEL_PROVIDER_ENDPOINT;OBOT_VLLM_MODEL_PROVIDER_API_KEY as env_vars
 Metadata: noUserAuth: vllm-model-provider
@@ -19,7 +19,9 @@ Metadata: noUserAuth: vllm-model-provider
             "friendlyName": "Endpoint",
             "description": "Endpoint for the vLLM OpenAI service (eg. http://localhost:8000)",
             "sensitive": false
-        },
+        }
+    ],
+    "optionalEnvVars": [
         {
             "name": "OBOT_VLLM_MODEL_PROVIDER_API_KEY",
             "friendlyName": "API Key",


### PR DESCRIPTION
vLLM doesn't require specifying an API Key

New:
![Screenshot 2025-03-07 at 15-08-54 Obot • Model Providers](https://github.com/user-attachments/assets/f5a70ca6-8aa8-4f36-9928-cd0b946107d0)

Issue: https://github.com/obot-platform/obot/issues/1967