### PR TITLE
fix: generated image download path

### DIFF
--- a/images/src/analyze.ts
+++ b/images/src/analyze.ts
@@ -59,7 +59,7 @@ export async function analyzeImages(
 const supportedMimeTypes = ['image/jpeg', 'image/png', 'image/webp'];
 const threadId = process.env.OBOT_THREAD_ID
 const obotServerUrl = process.env.OBOT_SERVER_URL
-const imageGenBaseUrl = (threadId && obotServerUrl) ? `${obotServerUrl}/api/threads/${threadId}/files/` : null
+const imageGenBaseUrl = (threadId && obotServerUrl) ? `${obotServerUrl}/api/threads/${threadId}/file/` : null
 
 async function resolveImageURL (image: string): Promise<string> {
   // If the image is a URL, return it as is
@@ -99,9 +99,9 @@ async function readImageFile(path: string): Promise<Buffer> {
 
   // The Generate Images tool returns file paths with a special prefix
   // so that they can be rendered in the Obot UI.
-  // e.g. /api/threads/<thread-id>/files/generated_image_<hash>.webp
+  // e.g. /api/threads/<thread-id>/file/generated_image_<hash>.webp
   // It must be stripped before reading the file from the workspace
-  path = path.replace(/^\/?api\/threads\/[a-z0-9]+\/files\//, '')
+  path = path.replace(/^\/?api\/threads\/[a-z0-9]+\/file\//, '')
 
   const client = new GPTScript()
   return Buffer.from(await client.readFileInWorkspace(`files/${path}`))

--- a/images/src/generate.ts
+++ b/images/src/generate.ts
@@ -9,7 +9,7 @@ type ImageQuality = 'standard' | 'hd';
 
 const threadId = process.env.OBOT_THREAD_ID
 const obotServerUrl = process.env.OBOT_SERVER_URL
-const downloadBaseUrl = (threadId && obotServerUrl) ? `${obotServerUrl}/api/threads/${threadId}/files` : null
+const downloadBaseUrl = (threadId && obotServerUrl) ? `${obotServerUrl}/api/threads/${threadId}/file` : null
 
 export async function generateImages(
   prompt: string = '',
@@ -81,14 +81,13 @@ async function download(client: gptscript.GPTScript, imageUrl: string): Promise<
     responseType: 'arraybuffer'
   })
   let content = Buffer.from(response.data, 'binary')
-
   // Convert the image to webp format
-  content = await sharp(content).webp({ quality: 100 }).toBuffer()
+  content = Buffer.from(await sharp(content).webp({ quality: 100 }).toBuffer())
 
   // Generate a SHA-256 hash of the imageURL to use as the filename
   const filePath = `generated_image_${createHash('sha256').update(imageUrl).digest('hex').substring(0, 8)}.webp`;
 
-  await client.writeFileInWorkspace(`${threadId ? 'files/' : ''}${filePath}`, content);
+  await client.writeFileInWorkspace(`${threadId ? 'files/' : ''}${filePath}`, content.buffer);
 
   return filePath
 }


### PR DESCRIPTION
Workspace files stored in the `files` directory are now served at `/api/threads/{threadId}/file/{file_name}` (`/file/` singular) instead of `/api/threads/{threadId}/files/{file_name}` (`/files/` plural). Update the `Generate Images` and
`Analyze Images` tools to comply with this change.

This fixes broken generated image links in the UI and when analyzing
them.

Addresses https://github.com/obot-platform/obot/issues/2005
