### PR TITLE
fix: update workspace read/write method, so it's clear it only supports plain text format

### DIFF
--- a/workspace-files/main.go
+++ b/workspace-files/main.go
@@ -23,6 +23,10 @@ var (
 	MaxFileSize = 250_000
 )
 
+var unsupportedFileTypes = []string{
+	".pdf", ".docx", ".doc", ".pptx", ".ppt", ".xlsx", ".xls", ".jpg", ".png", ".gif", ".mp3", ".mp4", ".zip", ".rar",
+}
+
 func main() {
 	if len(os.Args) == 1 {
 		fmt.Printf(`
@@ -169,6 +173,13 @@ func list(ctx context.Context, filename string) error {
 }
 
 func read(ctx context.Context, filename string) error {
+
+	for _, ext := range unsupportedFileTypes {
+		if strings.HasSuffix(strings.ToLower(filename), ext) {
+			return fmt.Errorf("reading files with extension %s is not supported", ext)
+		}
+	}
+
 	client, err := gptscript.NewGPTScript()
 	if err != nil {
 		return err
@@ -192,6 +203,13 @@ func read(ctx context.Context, filename string) error {
 }
 
 func write(ctx context.Context, filename, content string) error {
+	// Check if the file extension is unsupported
+	for _, ext := range unsupportedFileTypes {
+		if strings.HasSuffix(strings.ToLower(filename), ext) {
+			return fmt.Errorf("writing to files with extension %s is not supported", ext)
+		}
+	}
+
 	client, err := gptscript.NewGPTScript()
 	if err != nil {
 		return err

--- a/workspace-files/main.go
+++ b/workspace-files/main.go
@@ -174,6 +174,7 @@ func list(ctx context.Context, filename string) error {
 
 func read(ctx context.Context, filename string) error {
 
+	// Check for common binary file types that are not supported. Less common types should be caught by the utf8.Valid() check
 	for _, ext := range unsupportedFileTypes {
 		if strings.HasSuffix(strings.ToLower(filename), ext) {
 			return fmt.Errorf("reading files with extension %s is not supported", ext)

--- a/workspace-files/tool.gpt
+++ b/workspace-files/tool.gpt
@@ -23,6 +23,7 @@ to read and write in their user interface. You can collaborate with the user by 
 Do not ask first to create files in the workspace. Immediately write contents to the workspace as opposed to describing
 the contents to the user. If the user changes a file, they will inform you that content has changed, with the new
 contents of the file.
+If a file is not in plain text format, do not attempt to read it by copying it to a .txt file
 
 List of files in workspace:
 $FILES

--- a/workspace-files/tool.gpt
+++ b/workspace-files/tool.gpt
@@ -38,14 +38,14 @@ Params: dir: The directory to list files from
 
 ---
 Name: workspace_read
-Description: Read the contents of a file in the workspace
+Description: Read the contents of a file in the workspace. Supports only plain text formats (e.g., .txt, .md) and does not allow writing to binary files (e.g., .pdf, .docx, .pptx, .xlsx, .jpg, .png, .gif, .mp3, .mp4, .zip, .rar).
 Params: filename: The filename to read
 
 #!${GPTSCRIPT_TOOL_DIR}/bin/gptscript-go-tool read
 
 ---
 Name: workspace_write
-Description: Write contents to a file, overwriting the existing file if it exists.
+Description: Writes content to a file, replacing any existing content if the file already exists. Supports only plain text formats (e.g., .txt, .md) and does not allow writing to binary files (e.g., .pdf, .docx, .pptx, .xlsx, .jpg, .png, .gif, .mp3, .mp4, .zip, .rar).
 Params: filename: The filename to write to
 Params: content: The contents to write to the file
 

--- a/workspace-files/tool.gpt
+++ b/workspace-files/tool.gpt
@@ -38,14 +38,14 @@ Params: dir: The directory to list files from
 
 ---
 Name: workspace_read
-Description: Read the contents of a file in the workspace. Supports only plain text formats (e.g., .txt, .md) and does not allow writing to binary files (e.g., .pdf, .docx, .pptx, .xlsx, .jpg, .png, .gif, .mp3, .mp4, .zip, .rar).
+Description: Read the contents of a file in the workspace. Supports only plain text formats (e.g., .txt, .md).
 Params: filename: The filename to read
 
 #!${GPTSCRIPT_TOOL_DIR}/bin/gptscript-go-tool read
 
 ---
 Name: workspace_write
-Description: Writes content to a file, replacing any existing content if the file already exists. Supports only plain text formats (e.g., .txt, .md) and does not allow writing to binary files (e.g., .pdf, .docx, .pptx, .xlsx, .jpg, .png, .gif, .mp3, .mp4, .zip, .rar).
+Description: Writes content to a file, replacing any existing content if the file already exists. Supports only plain text formats (e.g., .txt, .md).
 Params: filename: The filename to write to
 Params: content: The contents to write to the file
 

--- a/workspace-files/tool.gpt
+++ b/workspace-files/tool.gpt
@@ -23,7 +23,7 @@ to read and write in their user interface. You can collaborate with the user by 
 Do not ask first to create files in the workspace. Immediately write contents to the workspace as opposed to describing
 the contents to the user. If the user changes a file, they will inform you that content has changed, with the new
 contents of the file.
-If a file is not in plain text format, do not attempt to read it by copying it to a .txt file
+Do NOT copy non-plain text files to .txt to read them. This won't make them readable.
 
 List of files in workspace:
 $FILES


### PR DESCRIPTION
 https://github.com/obot-platform/obot/issues/1986
