### PR TITLE
fix: cred helpers: migrate table if it doesn't exist

### DIFF
--- a/credential-stores/pkg/common/db.go
+++ b/credential-stores/pkg/common/db.go
@@ -35,7 +35,8 @@ type Database struct {
 }
 
 func NewDatabase(ctx context.Context, db *gorm.DB) (Database, error) {
-	if migrate {
+	migrator := db.Migrator()
+	if migrate || !migrator.HasTable(&GptscriptCredential{}) {
 		if err := db.AutoMigrate(&GptscriptCredential{}); err != nil {
 			return Database{}, fmt.Errorf("failed to auto migrate GptscriptCredential: %w", err)
 		}


### PR DESCRIPTION
This fixes a crash that can happen when running a brand new obot with an empty database.