### PR TITLE
fix: word_write: onedrive path . means root

### DIFF
--- a/word/pkg/graph/docs.go
+++ b/word/pkg/graph/docs.go
@@ -188,6 +188,9 @@ func CreateDoc(ctx context.Context, client *msgraphsdkgo.GraphServiceClient, nam
 		return "", "", fmt.Errorf("name cannot be empty")
 	}
 	dir := filepath.Dir(name)
+	if dir == "." {
+		dir = ""
+	}
 	name = filepath.Base(name)
 
 	// Get the user's drive.


### PR DESCRIPTION
Issue: https://github.com/obot-platform/obot/issues/1792

Before and After (compiled new tool in between):
![Screenshot 2025-03-12 at 20-31-39 thklein-dev](https://github.com/user-attachments/assets/9784818a-c1c1-4fff-aad3-2e9c887dadd6)
