### PR TITLE
fix: word/list: handle dataset create error

### DIFF
--- a/word/pkg/commands/list.go
+++ b/word/pkg/commands/list.go
@@ -40,6 +40,9 @@ func ListDocs(ctx context.Context) error {
 	datasetID, err := gptscriptClient.CreateDatasetWithElements(ctx, elements, gptscript.DatasetOptions{
 		Name: "word_docs_list",
 	})
+	if err != nil {
+		return fmt.Errorf("failed to create dataset: %w", err)
+	}
 
 	fmt.Printf("Created dataset with ID %s with %d docs\n", datasetID, len(elements))
 	return nil


### PR DESCRIPTION
Issue: https://github.com/obot-platform/obot/issues/1791 (not a fix, but related)