### PR TITLE
fix: cred helpers: sqlite: automigrate the gptscript_credentials table

### DIFF
--- a/credential-stores/sqlite/main.go
+++ b/credential-stores/sqlite/main.go
@@ -82,5 +82,9 @@ func NewSqlite(ctx context.Context) (common.Database, error) {
 		return common.Database{}, fmt.Errorf("failed to open database: %w", err)
 	}
 
+	if err := db.AutoMigrate(&common.GptscriptCredential{}); err != nil {
+		return common.Database{}, fmt.Errorf("failed to migrate database: %w", err)
+	}
+
 	return common.NewDatabase(ctx, db)
 }

--- a/credential-stores/sqlite/main.go
+++ b/credential-stores/sqlite/main.go
@@ -82,6 +82,8 @@ func NewSqlite(ctx context.Context) (common.Database, error) {
 		return common.Database{}, fmt.Errorf("failed to open database: %w", err)
 	}
 
+	// We always migrate the gptscript_credentials table for sqlite, because it is a separate database
+	// from the one managed by the main obot server.
 	if err := db.AutoMigrate(&common.GptscriptCredential{}); err != nil {
 		return common.Database{}, fmt.Errorf("failed to migrate database: %w", err)
 	}


### PR DESCRIPTION
This fixes an issue when running obot locally with sqlite. Credentials are stored in a separate database file from the rest of obot when running this way, meaning that this table never gets created by the main obot process, causing the credential helpers to always just return errors.