### PR TITLE
chore: remove shared time context from tools

### DIFF
--- a/bluesky/tool.gpt
+++ b/bluesky/tool.gpt
@@ -9,7 +9,6 @@ Name: Search Posts
 Description: Search for Bluesky posts
 Credential: ./credential
 JSON Response: true
-Share Context: Current Date and Time from ../time
 Share Tools: Search Users
 Param: query: A Lucene query to search for posts with.
 Param: since: (optional) ISO 8601 UTC timestamp to search for posts since (inclusive). Defaults to 7 days ago.
@@ -24,7 +23,6 @@ Name: Search Users
 Description: Search for Bluesky users
 Credential: ./credential
 JSON Response: true
-Share Context: Current Date and Time from ../time
 Param: query: A Lucene query to search for users with.
 Param: limit: (optional) The maximum number of users to return. Must be an integer >=1 and <=100. Defaults to 25.
 
@@ -35,7 +33,6 @@ Name: Create Post
 Description: Create a Bluesky post
 Credential: ./credential
 JSON Response: true
-Share Context: Current Date and Time from ../time
 Param: text: The text of the post.
 
 #!/usr/bin/env npm --silent --prefix ${GPTSCRIPT_TOOL_DIR} run tool -- createPost
@@ -45,7 +42,6 @@ Name: Delete Post
 Description: Delete a Bluesky post
 Credential: ./credential
 JSON Response: true
-Share Context: Current Date and Time from ../time
 Param: post_uri: The URI of the post to delete.
 
 #!/usr/bin/env npm --silent --prefix ${GPTSCRIPT_TOOL_DIR} run tool -- deletePost

--- a/browser/tool.gpt
+++ b/browser/tool.gpt
@@ -145,7 +145,6 @@ END TOOL USAGE: Download File From URL
 Name: Browser Context
 Metadata: index: false
 Type: context
-Share Context: Current Date and Time from ../time
 
 #!sys.echo
 

--- a/github/tool.gpt
+++ b/github/tool.gpt
@@ -9,7 +9,6 @@ Name: Search Issues and PRs
 Description: Search for issues and PRs in GitHub. Results are paginated, so in order to get all results for a search, call this function with the `page` parameter incremented by 1 until no results are returned.
 Credential: ./credential
 Share Context: GitHub Context
-Share Contexts: Current Date and Time from ../time
 Tools: github.com/gptscript-ai/datasets/filter
 Param: owner: (optional) the owner of the repository the issues or PRs belong to
 Param: repo: (optional) the name of the repository the issues or PRs belong to
@@ -36,7 +35,6 @@ Name: Create Issue
 Description: Create a new issue in the specified GitHub repository
 Credential: ./credential
 Share Context: GitHub Context
-Share Context: Current Date and Time from ../time
 Param: owner: the owner of the repository
 Param: repo: the name of the repository
 Param: title: the title of the issue
@@ -113,7 +111,6 @@ Name: Create PR
 Description: Create a new pull request in the specified GitHub repository
 Credential: ./credential
 Share Context: GitHub Context
-Share Context: Current Date and Time from ../time
 Param: owner: the owner of the repository
 Param: repo: the name of the repository
 Param: title: the title of the pull request

--- a/google/gmail/tool.gpt
+++ b/google/gmail/tool.gpt
@@ -15,7 +15,7 @@ Credential: ../credential
 Name: List Inbox
 Description: List emails in the user's Gmail inbox
 Credential: ../credential
-Share Contexts: Current Date and Time from ../../time, Email List Context
+Share Contexts: Email List Context
 Tools: github.com/gptscript-ai/datasets/filter
 Param: max_results: Maximum number of emails to list (Optional: Default will list 100 emails in the inbox)
 
@@ -35,7 +35,6 @@ Param: email_subject: Email subject to read (Optional: If not provided, email_id
 Name: Search Emails
 Description: Search a user's Gmail account for emails. Will return the email_id for each message. Can also be used to list emails in a folder or with a label.
 Credential: ../credential
-Share Contexts: Current Date and Time from ../../time
 Tools: github.com/gptscript-ai/datasets/filter
 Param: query: Search query to find emails in the user's Gmail account. Uses Gmail search syntax (e.g., "from:someuser@example.com rfc822msgid:<somemsgid@example.com> is:unread")
 Param: max_results: Maximum number of emails to list (Optional: Default will list 100 emails that match the query)
@@ -46,7 +45,6 @@ Param: max_results: Maximum number of emails to list (Optional: Default will lis
 Name: Send Email
 Description: Send an email from the user's Gmail account. Do not attempt to forward or reply to emails using this tool.
 Credential: ../credential
-Share Context: Current Date and Time from ../../time
 Param: to_emails: A comma separated list of email addresses to send the email to
 Param: cc_emails: A comma separated list of email addresses to cc the email to (Optional)
 Param: bcc_emails: A comma separated list of email addresses to bcc the email to (Optional)
@@ -68,7 +66,7 @@ Param: email_id: The ID of the email to delete
 Name: List Drafts
 Description: List drafts in a user's Gmail account
 Credential: ../credential
-Share Contexts: Current Date and Time from ../../time, Email List Context
+Share Contexts: Email List Context
 Tools: github.com/gptscript-ai/datasets/filter
 Param: max_results: Maximum number of drafts to list (Optional: Default will list 100 drafts)
 Param: attachments: A comma separated list of workspace file paths to attach to the email (Optional)
@@ -79,7 +77,6 @@ Param: attachments: A comma separated list of workspace file paths to attach to 
 Name: Create Draft
 Description: Create a draft email in a user's Gmail account.
 Credential: ../credential
-Share Context: Current Date and Time from ../../time
 Share Context: Draft Context
 Param: to_emails: A comma separated list of email addresses to send the email to
 Param: cc_emails: A comma separated list of email addresses to cc the email to (Optional)

--- a/google/search/tool.gpt
+++ b/google/search/tool.gpt
@@ -8,7 +8,6 @@ Share Tools: Search
 Name: Search
 Description: Search Google with a given query and return relevant information from the search results. Search with more maxResults if you need more information.
 JSON Response: true
-Share Context: Current Date and Time from ../../time
 Tools: service
 Args: query: A question, statement, or topic to search with (required)
 Args: maxResults: The maximum number of search results to gather relevant information from (optional, default 3, minimum 2)

--- a/linkedin-publishing/tool.gpt
+++ b/linkedin-publishing/tool.gpt
@@ -31,7 +31,6 @@ Param: share_media_file_path: (optional) the workspace file path for the share m
 ---
 Name: LinkedIn Publishing Context
 Type: context
-Share Context: ../time
 
 #!sys.echo
 

--- a/outlook/calendar/tool.gpt
+++ b/outlook/calendar/tool.gpt
@@ -129,7 +129,6 @@ Param: response: The response to the invitation. Possible values are "accept", "
 ---
 Name: Outlook Calendar Context
 Type: context
-Share Context: ../../time
 
 #!sys.echo
 

--- a/outlook/mail/tool.gpt
+++ b/outlook/mail/tool.gpt
@@ -135,7 +135,6 @@ Param: attachment_id: The ID of the attachment to get. Required.
 ---
 Name: Outlook Mail Context
 Type: context
-Share Context: ../../time
 
 #!sys.echo
 

--- a/search/google/googlecustomsearch/tool.gpt
+++ b/search/google/googlecustomsearch/tool.gpt
@@ -2,7 +2,6 @@
 Name: Google Custom Search
 Description: Search the Web using a Google Custom Search Engine.
 Credential: ./credential
-Share Context: ../../../time
 Param: query: The search query
 
 #!${GPTSCRIPT_TOOL_DIR}/bin/gptscript-go-tool

--- a/search/tavily/tool.gpt
+++ b/search/tavily/tool.gpt
@@ -34,7 +34,6 @@ Tavily Search
 ---
 Name: Tavily Context
 Type: context
-Share Context: ../../time
 
 #!sys.echo
 

--- a/search/tavily/websiteknowledge.gpt
+++ b/search/tavily/websiteknowledge.gpt
@@ -10,6 +10,5 @@ Param: query: The search query
 ---
 Name: tavily-safe-search-context
 Type: context
-Share Context: ../../time
 
 #!/usr/bin/env python3 ${GPTSCRIPT_TOOL_DIR}/main.py site-search-context Obot

--- a/slack/tool.gpt
+++ b/slack/tool.gpt
@@ -195,7 +195,6 @@ Credential: ./credential
 ---
 Name: Slack Context
 Type: context
-Share Context: ../time
 Share Tools: User Context
 
 #!sys.echo

--- a/wordpress/tool.gpt
+++ b/wordpress/tool.gpt
@@ -275,7 +275,6 @@ Param: tag_id: the ID of the tag to delete
 ---
 Name: Wordpress Context
 Type: context
-Share Context: ../time
 
 #!sys.echo
 

--- a/zoom/tool.gpt
+++ b/zoom/tool.gpt
@@ -171,7 +171,6 @@ Share Context: Zoom Context
 ---
 Name: Zoom Context
 Type: context
-Share Context: ../time
 
 #!sys.echo
 


### PR DESCRIPTION
The time context tools are shared by the Time bundle, which is included as `Optional - On` by the default Obot.

Addresses https://github.com/obot-platform/obot/issues/2039

