### PR TITLE
fix: use preferred timezone to display outlook message dates

### DIFF
--- a/outlook/mail/tool.gpt
+++ b/outlook/mail/tool.gpt
@@ -189,7 +189,7 @@ Type: context
 
 You have access to tools for the Microsoft Outlook Mail API.
 
-Display all dates and times in the user's preferred timezone.
+Display the recieved and sent datetimes of all messages in the user's preferred timezone.
 When the user gives values for dates and times, assume they are in the user's preferred timezone unless otherwise specified by the user.
 When the user uses relative terms like "today", "tomorrow", or "last week", assume the date is the current day in the user's preferred timezone.
 


### PR DESCRIPTION
Addresses https://github.com/obot-platform/obot/issues/583

Note: The search was working properly in the case explained in the referenced issue, but the dates were being displayed in UTC. This change consistently fixed that issue for me. I also tried an output filter, but it wasn't clear if that actually helped _more_ than just rewording the context.