### PR TITLE
feat: add respond_to_event tool to google calendar, update `Update Event`

### DIFF
--- a/google/calendar/main.py
+++ b/google/calendar/main.py
@@ -27,6 +27,8 @@ def main():
                 json_response = event_tools.move_event(service)
             case "update_event":
                 json_response = event_tools.update_event(service)
+            case "respond_to_event":
+                json_response = event_tools.respond_to_event(service)
             case "create_event":
                 json_response = event_tools.create_event(service)
             case "list_recurring_event_instances":

--- a/google/calendar/tool.gpt
+++ b/google/calendar/tool.gpt
@@ -2,7 +2,7 @@
 Name: Google Calendar
 Description: Tools for interacting with a user's Google Calendar account
 Metadata: bundle: true
-Share Tools: List Events, Get Event, Move Event, Quick Add Event, Create Event, Update Event, Delete Event, List Recurring Event Instances, List Calendars, Get Calendar, Create Calendar, Update Calendar, Delete Calendar
+Share Tools: List Events, Get Event, Move Event, Quick Add Event, Create Event, Update Event, Respond To Event, Delete Event, List Recurring Event Instances, List Calendars, Get Calendar, Create Calendar, Update Calendar, Delete Calendar
 
 ---
 Name: List Events
@@ -112,6 +112,17 @@ Param: time_min: (Optional) Upper bound (exclusive) for an event's start time to
 Param: time_max: (Optional) Lower bound (exclusive) for an event's end time to filter by. Optional. The default is not to filter by end time. Must be an RFC3339 timestamp with mandatory time zone offset.
 
 #!/usr/bin/env python3 ${GPTSCRIPT_TOOL_DIR}/main.py list_recurring_event_instances
+
+---
+Name: Respond To Event
+Description: Respond to an Google Calendar event invitation
+Credential: ./credential
+Share Context: Google Calendar Context
+Param: calendar_id: (Required) ID of the calendar to respond to event in.
+Param: event_id: (Required) ID of the event to respond to.
+Param: response: (Required) Response to the event invitation. Must be one of 'accepted', 'declined', or 'tentative'.
+
+#!/usr/bin/env python3 ${GPTSCRIPT_TOOL_DIR}/main.py respond_to_event
 
 ---
 Name: List Calendars

--- a/google/calendar/tool.gpt
+++ b/google/calendar/tool.gpt
@@ -73,7 +73,7 @@ Param: recurrence: (Optional) A JSON array of RRULE, EXRULE, RDATE and EXDATE li
 
 ---
 Name: Update Event
-Description: Update an existing event in a google calendar. Only the fields that are provided will be updated.
+Description: Updates an existing event in a Google Calendar. Only the event organizer is allowed to make changes. Only the fields that are provided will be updated.
 Credential: ./credential
 Share Context: Google Calendar Context
 Param: calendar_id: (Required) ID of the calendar to update event in.
@@ -115,7 +115,7 @@ Param: time_max: (Optional) Lower bound (exclusive) for an event's end time to f
 
 ---
 Name: Respond To Event
-Description: Respond to an Google Calendar event invitation
+Description: Respond to an Google Calendar event invitation.
 Credential: ./credential
 Share Context: Google Calendar Context
 Param: calendar_id: (Required) ID of the calendar to respond to event in.

--- a/google/calendar/tools/helper.py
+++ b/google/calendar/tools/helper.py
@@ -59,11 +59,14 @@ def get_client(service_name: str = "calendar", version: str = "v3"):
 def get_obot_user_timezone():
     return os.getenv("OBOT_USER_TIMEZONE", "UTC").strip()
 
+
 def get_user_timezone(service):
     """Fetches the authenticated user's time zone from User's Google Calendar settings."""
     try:
         settings = service.settings().get(setting="timezone").execute()
-        return settings.get("value", get_obot_user_timezone())  # Default to Obot's user timezone if not found
+        return settings.get(
+            "value", get_obot_user_timezone()
+        )  # Default to Obot's user timezone if not found
     except HttpError as err:
         if err.status_code == 403:
             raise Exception(f"HttpError retrieving user timezone: {err}")


### PR DESCRIPTION
https://github.com/obot-platform/obot/issues/2042
This PR:
- adds a `Respond to Event` tool to the Google Calendar Tool, allowing users to respond to pending calendar invitations.
- make sure only the Event Organizer can `update` an event. Even attendees can only update their own copies of events anyway, but this will make it less confusing.