### PR TITLE
Fix: Google calendar Tool bugfix

### DIFF
--- a/google/calendar/tool.gpt
+++ b/google/calendar/tool.gpt
@@ -53,7 +53,7 @@ Param: text: (Required) Text string to add to the calendar.
 
 ---
 Name: Create Event
-Description: Create a new event in a google calendar
+Description: Create a new event in a google calendar. The event type is always set to "default".
 Credential: ./credential
 Share Context: Google Calendar Context
 Param: calendar_id: (Required) ID of the calendar to create event in. Set to `primary` to create event in the primary calendar.

--- a/google/calendar/tool.gpt
+++ b/google/calendar/tool.gpt
@@ -86,7 +86,8 @@ Param: start_date: (Optional) The date, in the format "yyyy-mm-dd", only used if
 Param: start_datetime: (Optional) Start date and time of the event to update. Must be a valid RFC 3339 formatted date/time string. A time zone offset is required unless a time zone is explicitly specified in timeZone.
 Param: end_date: (Optional) The date, in the format "yyyy-mm-dd", if this is an all-day event.
 Param: end_datetime: (Optional) End date and time of the event to update. Must be a valid RFC 3339 formatted date/time string. A time zone offset is required unless a time zone is explicitly specified in timeZone.
-Param: attendees: (Optional) A comma separated list of email addresses of the attendees.
+Param: add_attendees: (Optional) A comma separated list of email addresses of the attendees. This will add the new attendees to the existing attendees list.
+Param: replace_attendees: (Optional) A comma separated list of email addresses of the attendees. This is only valid when add_attendees is empty. This will replace the existing attendees list with the new list.
 Param: recurrence: (Optional) A JSON array of RRULE, EXRULE, RDATE and EXDATE lines for a recurring event, as specified in RFC5545. Note that DTSTART and DTEND lines are not allowed in this field, because they are already specified in the start_datetime and end_datetime fields.
 
 #!/usr/bin/env python3 ${GPTSCRIPT_TOOL_DIR}/main.py update_event

--- a/google/calendar/tools/event.py
+++ b/google/calendar/tools/event.py
@@ -290,16 +290,19 @@ def create_event(service):
         try:
             recurrence_list = json.loads(recurrence)
         except json.JSONDecodeError:
-            raise ValueError(
-                f"Invalid recurrence list: {recurrence}. It must be a valid JSON array."
-            )
-        finally:
-            for r in recurrence_list:
-                if not _validate_rrule(r):
-                    raise ValueError(
-                        f"Invalid recurrence rule: {r}. It must be a valid RRULE string."
-                    )
-            event_body["recurrence"] = recurrence_list
+            if _validate_rrule(recurrence): # even if it's not a list,  check if it's a valid recurrence rule, if yes, wrap it in a list
+                recurrence_list = [recurrence]
+            else: # if it's not a valid recurrence rule, raise an error
+                raise ValueError(
+                    f"Invalid recurrence list: {recurrence}. It must be a valid JSON array."
+                )
+
+        for r in recurrence_list:
+            if not _validate_rrule(r):
+                raise ValueError(
+                    f"Invalid recurrence rule: {r}. It must be a valid RRULE string."
+                )
+        event_body["recurrence"] = recurrence_list
 
     attendees = os.getenv(
         "ATTENDEES"

--- a/google/calendar/tools/event.py
+++ b/google/calendar/tools/event.py
@@ -569,27 +569,27 @@ def update_event(service):
     except Exception as e:
         raise Exception(f"Exception retrieving event {event_id}: {e}")
 
-    def raise_field_update_error(field: str, event_type: str):
-        raise PermissionError(
-            f"Updating property '{field}' for event type '{event_type}' is not allowed."
+    def return_field_update_error(field: str, event_type: str):
+        return (
+            f"Error: Updating property '{field}' for event type '{event_type}' is not allowed."
         )
 
     event_body = {}
     summary = os.getenv("SUMMARY")
     if summary:
         if not _can_update_property(existing_event_type, "summary"):
-            raise_field_update_error("summary", existing_event_type)
+            return return_field_update_error("summary", existing_event_type)
 
         event_body["summary"] = summary
     location = os.getenv("LOCATION")
     if location:
         if not _can_update_property(existing_event_type, "location"):
-            raise_field_update_error("location", existing_event_type)
+            return return_field_update_error("location", existing_event_type)
         event_body["location"] = location
     description = os.getenv("DESCRIPTION")
     if description:
         if not _can_update_property(existing_event_type, "description"):
-            raise_field_update_error("description", existing_event_type)
+            return return_field_update_error("description", existing_event_type)
         event_body["description"] = description
 
     time_zone = os.getenv("TIME_ZONE")
@@ -600,7 +600,7 @@ def update_event(service):
 
     start = {}
     if not _can_update_property(existing_event_type, "start"):
-        raise_field_update_error("start", existing_event_type)
+        return return_field_update_error("start", existing_event_type)
 
     start_date = os.getenv("START_DATE")
     start_datetime = os.getenv("START_DATETIME")
@@ -623,7 +623,7 @@ def update_event(service):
 
     end = {}
     if not _can_update_property(existing_event_type, "end"):
-        raise_field_update_error("end", existing_event_type)
+        return return_field_update_error("end", existing_event_type)
 
     end_date = os.getenv("END_DATE")
     end_datetime = os.getenv("END_DATETIME")
@@ -647,7 +647,7 @@ def update_event(service):
     recurrence = os.getenv("RECURRENCE")
     if recurrence:
         if not _can_update_property(existing_event_type, "recurrence"):
-            raise_field_update_error("recurrence", existing_event_type)
+            return return_field_update_error("recurrence", existing_event_type)
 
         try:
             recurrence_list = json.loads(recurrence)
@@ -668,7 +668,7 @@ def update_event(service):
 
     if add_attendees or replace_attendees:
         if not _can_update_property(existing_event_type, "attendees"):
-            raise_field_update_error("attendees", existing_event_type)
+            return return_field_update_error("attendees", existing_event_type)
 
         existing_attendees = existing_event.get("attendees", [])
         existing_attendee_map = {


### PR DESCRIPTION
https://github.com/obot-platform/obot/issues/2328
- handle the case when the recurrence rule is not a json array.
- Return a clear error message when the agent attempts to update a property that exists on the event, but is not updatable for its eventType according to the Google Calendar API.
- preserve full metadata of existing attendees when updating an event.