### PR TITLE
feat: rewrite anthropic-model-provider as openai-style proxy in Go and add thinking mode

### DIFF
--- a/anthropic-model-provider-go/go.mod
+++ b/anthropic-model-provider-go/go.mod
@@ -1,0 +1,11 @@
+module github.com/obot-platform/tools/anthropic-model-provider
+
+go 1.24.1
+
+replace (
+	github.com/obot-platform/tools/openai-model-provider => ../openai-model-provider
+)
+require (
+	github.com/gptscript-ai/chat-completion-client v0.0.0-20250123123106-c86554320789
+	github.com/obot-platform/tools/openai-model-provider v0.0.0-20250327233502-e281d9bc8d01
+)

--- a/anthropic-model-provider-go/go.sum
+++ b/anthropic-model-provider-go/go.sum
@@ -1,0 +1,4 @@
+github.com/gptscript-ai/chat-completion-client v0.0.0-20250123123106-c86554320789 h1:rfriXe+FFqZ5fZ+wGzLUivrq7Fyj2xfRdZjDsHf6Ps0=
+github.com/gptscript-ai/chat-completion-client v0.0.0-20250123123106-c86554320789/go.mod h1:7P/o6/IWa1KqsntVf68hSnLKuu3+xuqm6lYhch1w4jo=
+github.com/obot-platform/tools/openai-model-provider v0.0.0-20250327233502-e281d9bc8d01 h1:EHuO9lklHtcQM6rbvFftXBhLYWHyxjtJ2U9jtisgnok=
+github.com/obot-platform/tools/openai-model-provider v0.0.0-20250327233502-e281d9bc8d01/go.mod h1:Cu5QvjNTIpjldsG0LASkAPMKNBV090IUcSxqqwbWmLg=

--- a/anthropic-model-provider-go/main.go
+++ b/anthropic-model-provider-go/main.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httputil"
+	"os"
+
+	aproxy "github.com/obot-platform/tools/anthropic-model-provider/proxy"
+	"github.com/obot-platform/tools/openai-model-provider/proxy"
+)
+
+func main() {
+	isValidate := len(os.Args) > 1 && os.Args[1] == "validate"
+
+	cfg := &proxy.Config{
+		APIKey:          os.Getenv("OBOT_ANTHROPIC_MODEL_PROVIDER_API_KEY"), // optional, as e.g. Ollama doesn't require an API key
+		ListenPort:      os.Getenv("PORT"),
+		BaseURL:         "https://api.anthropic.com/v1/",
+		RewriteModelsFn: aproxy.RewriteModelsResponse,
+		RewriteHeaderFn: func(header http.Header) {
+			header.Del("Authorization")
+			header.Set("x-api-key", os.Getenv("OBOT_ANTHROPIC_MODEL_PROVIDER_API_KEY"))
+			header.Set("anthropic-version", "2023-06-01")
+		},
+		Name: "Anthropic",
+	}
+
+	prox := aproxy.NewServer(cfg)
+	reverseProxy := &httputil.ReverseProxy{
+		Director: prox.AnthropicProxyRedirect,
+	}
+	reverseProxyModels := &httputil.ReverseProxy{
+		Director:       prox.AnthropicProxyRedirect,
+		ModifyResponse: aproxy.RewriteModelsResponse,
+	}
+	cfg.CustomPathHandleFuncs = map[string]http.HandlerFunc{
+		"/v1/models": reverseProxyModels.ServeHTTP,
+		"/v1/":       reverseProxy.ServeHTTP,
+	}
+
+	if err := cfg.Validate("/tools/anthropic-model-provider/validate"); err != nil {
+		os.Exit(1)
+	}
+
+	if isValidate {
+		return
+	}
+
+	if err := proxy.Run(cfg); err != nil {
+		fmt.Printf("failed to run anthropic-model-provider proxy: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/anthropic-model-provider-go/proxy/models.go
+++ b/anthropic-model-provider-go/proxy/models.go
@@ -1,0 +1,75 @@
+package proxy
+
+import (
+	"bytes"
+	"compress/gzip"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"slices"
+	"strings"
+
+	"github.com/obot-platform/tools/openai-model-provider/api"
+)
+
+var thinkingModels = []string{
+	"claude-3-7-sonnet",
+}
+
+// RewriteModelsResponse returns a response modifier that marks all models with the specified usage
+func RewriteModelsResponse(resp *http.Response) error {
+	if resp.StatusCode != http.StatusOK {
+		return nil
+	}
+
+	defer resp.Body.Close()
+
+	var body io.Reader = resp.Body
+	if resp.Header.Get("Content-Encoding") == "gzip" {
+		gzReader, err := gzip.NewReader(resp.Body)
+		if err != nil {
+			return fmt.Errorf("failed to create gzip reader: %w", err)
+		}
+		defer gzReader.Close()
+		resp.Header.Del("Content-Encoding")
+		body = gzReader
+	}
+
+	var models api.ModelsResponse
+	if err := json.NewDecoder(body).Decode(&models); err != nil {
+		return fmt.Errorf("failed to decode models response: %w", err)
+	}
+
+	var extraModels []api.Model
+	for i, model := range models.Data {
+		if model.Metadata == nil {
+			model.Metadata = make(map[string]string)
+		}
+		model.Metadata["usage"] = "llm"
+		models.Data[i] = model
+
+		if slices.ContainsFunc(thinkingModels, func(m string) bool {
+			return strings.HasPrefix(model.ID, m)
+		}) {
+			extraModels = append(extraModels, api.Model{
+				ID:       model.ID + "-thinking",
+				Metadata: model.Metadata,
+				Created:  model.Created,
+				Object:   model.Object,
+				OwnedBy:  model.OwnedBy,
+			})
+		}
+	}
+
+	models.Data = append(models.Data, extraModels...)
+
+	b, err := json.Marshal(models)
+	if err != nil {
+		return fmt.Errorf("failed to marshal models response: %w", err)
+	}
+
+	resp.Body = io.NopCloser(bytes.NewReader(b))
+	resp.Header.Set("Content-Length", fmt.Sprintf("%d", len(b)))
+	return nil
+}

--- a/anthropic-model-provider-go/proxy/proxy.go
+++ b/anthropic-model-provider-go/proxy/proxy.go
@@ -45,7 +45,7 @@ func (s *Server) AnthropicProxyRedirect(req *http.Request) {
 	var reqBody openai.ChatCompletionRequest
 	if err := json.Unmarshal(bodyBytes, &reqBody); err == nil && needsModification(reqBody) {
 		if err := modifyRequestBody(req, &reqBody); err != nil {
-			fmt.Println("failed to modify request body for o1, error: ", err.Error())
+			fmt.Println("failed to modify request body for claude, error: ", err.Error())
 			req.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
 		}
 	} else {

--- a/anthropic-model-provider-go/proxy/proxy.go
+++ b/anthropic-model-provider-go/proxy/proxy.go
@@ -1,0 +1,105 @@
+package proxy
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	openai "github.com/gptscript-ai/chat-completion-client"
+	"github.com/obot-platform/tools/openai-model-provider/proxy"
+)
+
+const AnthropicBaseHostName = "api.anthropic.com"
+
+type Server struct {
+	cfg *proxy.Config
+}
+
+func NewServer(cfg *proxy.Config) *Server {
+	return &Server{cfg: cfg}
+}
+
+func (s *Server) AnthropicProxyRedirect(req *http.Request) {
+	req.URL.Scheme = s.cfg.URL.Scheme
+	req.URL.Host = s.cfg.URL.Host
+	req.URL.Path = s.cfg.URL.JoinPath(strings.TrimPrefix(req.URL.Path, "/v1")).Path
+	req.Host = req.URL.Host
+
+	req.Header.Del("Authorization")
+	req.Header.Set("x-api-key", s.cfg.APIKey)
+	req.Header.Set("anthropic-version", "2023-06-01")
+
+	if req.Body == nil || s.cfg.URL.Host != AnthropicBaseHostName || req.URL.Path != proxy.ChatCompletionsPath {
+		return
+	}
+
+	bodyBytes, err := io.ReadAll(req.Body)
+	if err != nil {
+		fmt.Println("failed to read request body, error: ", err.Error())
+		return
+	}
+
+	var reqBody openai.ChatCompletionRequest
+	if err := json.Unmarshal(bodyBytes, &reqBody); err == nil && needsModification(reqBody) {
+		if err := modifyRequestBody(req, &reqBody); err != nil {
+			fmt.Println("failed to modify request body for o1, error: ", err.Error())
+			req.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
+		}
+	} else {
+		req.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
+	}
+}
+
+type ThinkingConfig struct {
+	Type         string `json:"type"`
+	BudgetTokens int    `json:"budget_tokens"`
+}
+
+type ThinkingRequestBody struct {
+	openai.ChatCompletionRequest
+	Thinking ThinkingConfig `json:"thinking,omitempty"`
+}
+
+func isThinkingModel(model string) bool {
+	if strings.HasSuffix(model, "-thinking") {
+		return true
+	}
+	return false
+}
+
+func needsModification(reqBody openai.ChatCompletionRequest) bool {
+	return isThinkingModel(reqBody.Model)
+}
+
+func modifyRequestBody(req *http.Request, reqBody *openai.ChatCompletionRequest) error {
+	var modifiedBodyBytes []byte
+	var err error
+	if isThinkingModel(reqBody.Model) {
+		reqBody.Model = strings.TrimSuffix(reqBody.Model, "-thinking") // remove our custom -thinking suffix
+		reqBody.MaxTokens = 64000                                      // set max tokens to 64000, which is the current max for 3.7 Sonnet in extended thinking mode
+		temp := float32(1)
+		reqBody.Temperature = &temp
+		thinkingReqBody := &ThinkingRequestBody{
+			ChatCompletionRequest: *reqBody,
+			Thinking: ThinkingConfig{
+				Type:         "enabled",
+				BudgetTokens: 64000 / 2, // TODO: is 50% of max tokens a good default?
+			},
+		}
+		modifiedBodyBytes, err = json.Marshal(thinkingReqBody)
+		if err != nil {
+			return err
+		}
+	} else {
+		modifiedBodyBytes, err = json.Marshal(reqBody)
+		if err != nil {
+			return fmt.Errorf("failed to marshal request body after modification: %w", err)
+		}
+	}
+	req.Body = io.NopCloser(bytes.NewBuffer(modifiedBodyBytes))
+	req.ContentLength = int64(len(modifiedBodyBytes))
+	return nil
+}

--- a/anthropic-model-provider-go/proxy/proxy.go
+++ b/anthropic-model-provider-go/proxy/proxy.go
@@ -64,10 +64,7 @@ type ThinkingRequestBody struct {
 }
 
 func isThinkingModel(model string) bool {
-	if strings.HasSuffix(model, "-thinking") {
-		return true
-	}
-	return false
+	return strings.HasSuffix(model, "-thinking")
 }
 
 func needsModification(reqBody openai.ChatCompletionRequest) bool {

--- a/anthropic-model-provider-go/tool.gpt
+++ b/anthropic-model-provider-go/tool.gpt
@@ -1,0 +1,30 @@
+Name: Anthropic
+Description: Model provider for Anthropic hosted Claude models
+Model Provider: true
+Credential: ../placeholder-credential as anthropic-model-provider with OBOT_ANTHROPIC_MODEL_PROVIDER_API_KEY as env_vars
+Metadata: noUserAuth: anthropic-model-provider
+
+
+#!sys.daemon ${GPTSCRIPT_TOOL_DIR}/bin/gptscript-go-tool
+
+---
+!metadata:Anthropic:providerMeta
+{
+    "icon": "/admin/assets/anthropic_icon.svg",
+    "link": "https://www.anthropic.com",
+    "description": "Note: Anthropic does not have an embeddings model and [recommends](https://docs.anthropic.com/en/docs/build-with-claude/embeddings) Voyage AI.",
+    "envVars": [
+        {
+            "name": "OBOT_ANTHROPIC_MODEL_PROVIDER_API_KEY",
+            "friendlyName": "API Key",
+            "description": "Anthropic API Key",
+            "sensitive": true
+        }
+    ]
+}
+
+---
+Name: validate
+Description: Validate Anthropic credentials
+
+#!${GPTSCRIPT_TOOL_DIR}/bin/gptscript-go-tool validate

--- a/index.yaml
+++ b/index.yaml
@@ -136,7 +136,7 @@ modelProviders:
   openai-model-provider:
     reference: ./openai-model-provider
   anthropic-model-provider:
-    reference: ./anthropic-model-provider
+    reference: ./anthropic-model-provider-go
   ollama-model-provider:
     reference: ./ollama-model-provider
   groq-model-provider:

--- a/openai-model-provider/proxy/validate.go
+++ b/openai-model-provider/proxy/validate.go
@@ -3,20 +3,21 @@ package proxy
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 
 	"github.com/obot-platform/tools/openai-model-provider/api"
 )
 
-func handleValidationError(loggerPath, msg string) error {
-	slog.Error(msg, "logger", loggerPath)
+func handleValidationError(err error, loggerPath, msg string) error {
+	slog.Error(msg, "logger", loggerPath, "error", err)
 	fmt.Printf("{\"error\": \"%s\"}\n", msg)
 	return fmt.Errorf(msg)
 }
 
 func (cfg *Config) Validate(toolPath string) error {
-	if err := cfg.ensureURL(); err != nil {
+	if err := cfg.EnsureURL(); err != nil {
 		return fmt.Errorf("failed to ensure URL: %w", err)
 	}
 
@@ -24,30 +25,38 @@ func (cfg *Config) Validate(toolPath string) error {
 
 	req, err := http.NewRequest("GET", url.String(), nil)
 	if err != nil {
-		return handleValidationError(toolPath, fmt.Sprintf("Invalid %s Configuration", cfg.Name))
+		return handleValidationError(err, toolPath, fmt.Sprintf("Invalid %s Configuration", cfg.Name))
 	}
 
 	req.Header.Set("Authorization", "Bearer "+cfg.APIKey)
 	req.Header.Set("Accept", "application/json")
 
+	if cfg.RewriteHeaderFn != nil {
+		cfg.RewriteHeaderFn(req.Header)
+	}
+
 	client := &http.Client{}
 	resp, err := client.Do(req)
 	if err != nil {
-		return handleValidationError(toolPath, fmt.Sprintf("Invalid %s Configuration", cfg.Name))
+		return handleValidationError(err, toolPath, fmt.Sprintf("Invalid %s Configuration", cfg.Name))
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return handleValidationError(toolPath, fmt.Sprintf("Invalid %s Credentials", cfg.Name))
+		if resp.Body != nil {
+			body, _ := io.ReadAll(resp.Body)
+			return handleValidationError(fmt.Errorf("status %s: %s", resp.Status, string(body)), toolPath, fmt.Sprintf("Invalid %s Credentials", cfg.Name))
+		}
+		return handleValidationError(fmt.Errorf("status %s", resp.Status), toolPath, fmt.Sprintf("Invalid %s Credentials", cfg.Name))
 	}
 
 	var modelsResp api.ModelsResponse
 	if err := json.NewDecoder(resp.Body).Decode(&modelsResp); err != nil {
-		return handleValidationError(toolPath, "Invalid Response Format")
+		return handleValidationError(err, toolPath, "Invalid Response Format")
 	}
 
 	if modelsResp.Object != "" && modelsResp.Object != "list" || len(modelsResp.Data) == 0 {
-		return handleValidationError(toolPath, fmt.Sprintf("Invalid Models Response: %d models", len(modelsResp.Data)))
+		return handleValidationError(nil, toolPath, fmt.Sprintf("Invalid Models Response: %d models", len(modelsResp.Data)))
 	}
 
 	return nil


### PR DESCRIPTION
We cannot replace the Python implementation yet since the anthropic-bedrock provider is still relying on it.

Issue: https://github.com/obot-platform/obot/issues/1999