### PR TITLE
fix: removed useless meeting series UUIDs in APIresponses from Zoom Tool

### DIFF
--- a/zoom/tool.gpt
+++ b/zoom/tool.gpt
@@ -2,7 +2,7 @@
 Name: Zoom
 Description: Tools for interacting with Zoom
 Metadata: bundle: true
-Share Tools: Get Zoom User, Create Meeting, Update Meeting, List Meeting Templates, Get Meeting, Delete Meeting, List Meetings, List Upcoming Meetings, List Past Meeting Instances, Get Past Meeting Details, Get Meeting Invitation, Get Meeting Cloud Recordings, List User Cloud Recordings, Get Meeting Summary, List Available Timezones
+Share Tools: Get Zoom User, Create Meeting, Update Meeting, List Meeting Templates, Get Hosted Meeting, Delete Meeting, List Hosted Meetings, List Upcoming Meetings, List Past Meeting Instances, Get Past Meeting Details, Get Meeting Invitation, Get Meeting Cloud Recordings, List User Cloud Recordings, Get AI Meeting Summary, List Available Timezones
 
 ---
 Name: Get Zoom User
@@ -14,7 +14,7 @@ Share Context: Zoom Context
 
 ---
 Name: Create Meeting
-Description: Use this tool to create a Zoom meeting.
+Description: Use this tool to create a Zoom meeting. The user will be the host of the meeting.
 Credential: ./credential
 Share Context: Zoom Context
 Param: meeting_invitees: Optional. A list of emails separated by commas
@@ -73,8 +73,8 @@ Share Context: Zoom Context
 #!/usr/bin/env python3 ${GPTSCRIPT_TOOL_DIR}/main.py ListMeetingTemplates
 
 ---
-Name: Get Meeting
-Description: Get a Zoom meeting's details information. The meeting must be hosted by the current Zoom user.
+Name: Get Hosted Meeting
+Description: Get details of a Zoom meeting hosted by the current Zoom user.
 Credential: ./credential
 Share Context: Zoom Context
 Param: meeting_id: The ID of the meeting to get
@@ -91,7 +91,7 @@ Param: meeting_id: The ID of the meeting to delete
 #!/usr/bin/env python3 ${GPTSCRIPT_TOOL_DIR}/main.py DeleteMeeting
 
 ---
-Name: List Meetings
+Name: List Hosted Meetings
 Description: List all scheduled meetings hosted by the current Zoom user. This does not return information about instant meetings.
 Credential: ./credential
 Share Context: Zoom Context
@@ -152,11 +152,11 @@ Param: meeting_id: The ID of the meeting to get the instances for
 #!/usr/bin/env python3 ${GPTSCRIPT_TOOL_DIR}/main.py ListPastMeetingInstances
 
 ---
-Name: Get Meeting Summary
+Name: Get AI Meeting Summary
 Description: Retrieve the Zoom AI-generated summary of a Zoom meeting. This feature is available exclusively to licensed users. To access it, the host must ensure that the `Meeting Summary with AI Companion` feature is enabled in their account settings. The meeting summary's accessibility depends on the host's sharing settings, by default only the host has the access.
 Credential: ./credential
 Share Context: Zoom Context
-Param: meeting_uuid: The UUID of the meeting to get the summary for, NOT the meeting ID. Must use the UUID obtained from `Get Past Meeting Details` tool.
+Param: meeting_uuid: The UUID of the meeting to get the summary for, NOT the meeting ID.
 
 #!/usr/bin/env python3 ${GPTSCRIPT_TOOL_DIR}/main.py GetMeetingSummary
 
@@ -171,6 +171,7 @@ Share Context: Zoom Context
 ---
 Name: Zoom Context
 Type: context
+Share Context: ../time
 
 #!sys.echo
 

--- a/zoom/tools/meetings.py
+++ b/zoom/tools/meetings.py
@@ -106,6 +106,30 @@ def _trim_meeting_id(meeting_id_or_uuid: str) -> str:
     return "".join(meeting_id_or_uuid.split())
 
 
+def _remove_meeting_series_uuid(response_json: dict) -> dict:
+    """
+    Remove the meeting series uuid from the response json if APIs:
+    - Get Meeting
+    - List Meetings
+    - List Upcoming Meetings
+    - Create Meeting
+    - Update Meeting
+    """
+
+    if "uuid" in response_json:
+        response_json.pop("uuid", None)
+    elif "meetings" in response_json:
+        for meeting in response_json["meetings"]:
+            if "uuid" in meeting:
+                meeting.pop("uuid", None)
+
+    return response_json
+
+
+def _is_meeting_id(value: str) -> bool:
+    return value.isdigit() and 9 <= len(value) <= 11
+
+
 _meeting_types = {
     1: "An instant meeting",
     2: "A scheduled meeting",
@@ -253,7 +277,9 @@ def create_meeting():
     response = requests.post(url, json=payload, headers=headers)
     if response.status_code != 201:
         return {"message": f"Error creating meeting: {response.text}"}
-    return response.json()
+
+    cleaned_json = _remove_meeting_series_uuid(response.json())
+    return cleaned_json
 
 
 def _get_meeting():
@@ -282,7 +308,10 @@ def get_meeting():
             res_json["start_time"], res_json["timezone"]
         )
         res_json["start_time_utc"] = res_json.pop("start_time")
-    return res_json
+
+    if "uuid" in res_json:
+        res_json.pop("uuid", None)
+    return _remove_meeting_series_uuid(res_json)
 
 
 @tool_registry.decorator("DeleteMeeting")
@@ -337,7 +366,10 @@ def list_meetings():
                 meeting["start_time"], meeting["timezone"]
             )
             meeting["start_time_utc"] = meeting.pop("start_time")
-    return res_json
+
+        if "uuid" in meeting:
+            meeting.pop("uuid", None)
+    return _remove_meeting_series_uuid(res_json)
 
 
 @tool_registry.decorator("ListUpcomingMeetings")
@@ -362,7 +394,7 @@ def list_upcoming_meetings():
                 meeting["start_time"], meeting["timezone"]
             )
             meeting["start_time_utc"] = meeting.pop("start_time")
-    return res_json
+    return _remove_meeting_series_uuid(res_json)
 
 
 @tool_registry.decorator("GetMeetingInvitation")
@@ -498,6 +530,11 @@ def get_meeting_summary():
             "The `Get Meeting Summary` feature is only available for licensed users."
         )
     meeting_uuid = _trim_meeting_id(os.environ["MEETING_UUID"])
+    if _is_meeting_id(meeting_uuid):
+        return {
+            "message": "ValueError: Meeting UUID must be provided instead of meeting ID."
+        }
+
     url = f"{ZOOM_API_URL}/meetings/{meeting_uuid}/meeting_summary"
     headers = {
         "Authorization": f"Bearer {ACCESS_TOKEN}",

--- a/zoom/tools/meetings.py
+++ b/zoom/tools/meetings.py
@@ -309,8 +309,6 @@ def get_meeting():
         )
         res_json["start_time_utc"] = res_json.pop("start_time")
 
-    if "uuid" in res_json:
-        res_json.pop("uuid", None)
     return _remove_meeting_series_uuid(res_json)
 
 
@@ -367,8 +365,7 @@ def list_meetings():
             )
             meeting["start_time_utc"] = meeting.pop("start_time")
 
-        if "uuid" in meeting:
-            meeting.pop("uuid", None)
+
     return _remove_meeting_series_uuid(res_json)
 
 


### PR DESCRIPTION
This PR to address issue comments: https://github.com/obot-platform/obot/issues/1892#issuecomment-2770813691

- removed meeting series UUIDs from the API responses. This helps the Obot agent to find the correct meeting UUID to get AI meeting summaries.
- Other prompts fixes.