### PR TITLE
fix: detect userType and return Proper error message when user has no permission

### DIFF
--- a/outlook/mail/pkg/commands/listGroups.go
+++ b/outlook/mail/pkg/commands/listGroups.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/gptscript-ai/tools/outlook/mail/pkg/client"
 	"github.com/gptscript-ai/tools/outlook/mail/pkg/global"
@@ -18,6 +19,11 @@ func ListGroups(ctx context.Context) error {
 
 	groups, err := graph.ListGroups(ctx, c)
 	if err != nil {
+		userType, getUserTypeErr := graph.GetUserType(ctx, c)
+		if getUserTypeErr == nil && strings.EqualFold(userType, "Guest") {
+			fmt.Printf("UserType '%s' does not have enough permissions to list groups.\n", userType)
+			return nil
+		}
 		return fmt.Errorf("failed to list groups: %w", err)
 	}
 
@@ -31,7 +37,7 @@ func ListGroups(ctx context.Context) error {
 	}
 
 	for _, group := range groups {
-		fmt.Printf("ID: %s\nName: %s\nDescription: %s\nMail: %s\n",
+		fmt.Printf("ID: %s\nName: %s\nDescription: %s\nMail: %s\n\n",
 			util.Deref(group.GetId()),
 			util.Deref(group.GetDisplayName()),
 			util.Deref(group.GetDescription()),

--- a/outlook/mail/pkg/commands/listGroups.go
+++ b/outlook/mail/pkg/commands/listGroups.go
@@ -21,7 +21,7 @@ func ListGroups(ctx context.Context) error {
 	if err != nil {
 		userType, getUserTypeErr := graph.GetUserType(ctx, c)
 		if getUserTypeErr == nil && strings.EqualFold(userType, "Guest") {
-			fmt.Printf("UserType '%s' does not have enough permissions to list groups.\n", userType)
+			fmt.Printf("User has type '%s', which does not have enough permissions to list groups.\n", userType)
 			return nil
 		}
 		return fmt.Errorf("failed to list groups: %w", err)


### PR DESCRIPTION
To address issue comment : https://github.com/obot-platform/obot/issues/1940#issuecomment-2754881365

Guest users within a Microsoft organization are restricted from accessing Groups features.