### PR TITLE
fix: Google calendar recurrence rule string

### DIFF
--- a/google/calendar/tool.gpt
+++ b/google/calendar/tool.gpt
@@ -66,7 +66,7 @@ Param: start_datetime: (Optional) Start date and time of the event to create. Mu
 Param: end_date: (Optional) The date, in the format "yyyy-mm-dd", if this is an all-day event.
 Param: end_datetime: (Optional) End date and time of the event to create. Must be a valid RFC 3339 formatted date/time string. A time zone offset is required unless a time zone is explicitly specified in timeZone.
 Param: attendees: (Optional) A comma separated list of email addresses of the attendees.
-Param: recurrence: (Optional) A JSON array of RRULE, EXRULE, RDATE and EXDATE lines for a recurring event, as specified in RFC5545. Note that DTSTART and DTEND lines are not allowed in this field, because they are already specified in the start_datetime and end_datetime fields.
+Param: recurrence: (Optional) For a recurring event, provide a JSON array of strings, where each string is an RRULE, EXRULE, RDATE, or EXDATE line as defined by the RFC5545. For example,["RRULE:FREQ=YEARLY", "EXDATE:20250403T100000Z"]. Note that DTSTART and DTEND lines are not allowed in this field, because they are already specified in the start_datetime and end_datetime fields.
 
 #!/usr/bin/env python3 ${GPTSCRIPT_TOOL_DIR}/main.py create_event
 
@@ -88,7 +88,7 @@ Param: end_date: (Optional) The date, in the format "yyyy-mm-dd", if this is an 
 Param: end_datetime: (Optional) End date and time of the event to update. Must be a valid RFC 3339 formatted date/time string. A time zone offset is required unless a time zone is explicitly specified in timeZone.
 Param: add_attendees: (Optional) A comma separated list of email addresses of the attendees. This will add the new attendees to the existing attendees list.
 Param: replace_attendees: (Optional) A comma separated list of email addresses of the attendees. This is only valid when add_attendees is empty. This will replace the existing attendees list with the new list.
-Param: recurrence: (Optional) A JSON array of RRULE, EXRULE, RDATE and EXDATE lines for a recurring event, as specified in RFC5545. Note that DTSTART and DTEND lines are not allowed in this field, because they are already specified in the start_datetime and end_datetime fields.
+Param: recurrence: (Optional) For a recurring event, provide a JSON array of strings, where each string is an RRULE, EXRULE, RDATE, or EXDATE line as defined by the RFC5545. For example,["RRULE:FREQ=YEARLY", "EXDATE:20250403T100000Z"]. Note that DTSTART and DTEND lines are not allowed in this field, because they are already specified in the start_datetime and end_datetime fields.
 
 #!/usr/bin/env python3 ${GPTSCRIPT_TOOL_DIR}/main.py update_event
 

--- a/google/calendar/tools/event.py
+++ b/google/calendar/tools/event.py
@@ -413,6 +413,47 @@ def quick_add_event(service):
         raise Exception(f"Exception quick adding event to calendar {calendar_id}: {e}")
 
 
+def _get_recurrence_list(recurrence: str) -> list:
+    """
+    Parse a string into a list of recurrence rules.
+
+    Args:
+        recurrence (str): The recurrence string to parse
+
+    Raises:
+        ValueError: If the recurrence string is not a valid JSON array of strings, where each string is an RRULE, EXRULE, RDATE, or EXDATE line as defined by the RFC5545.
+        ValueError: If the recurrence string is not a valid recurrence rule syntax.
+
+    Returns:
+        list: A list of recurrence rules
+    """
+    try:
+        recurrence_list = json.loads(recurrence)
+    except json.JSONDecodeError:
+        try:
+            fixed_recurrence = recurrence.encode().decode(
+                "unicode_escape"
+            )  # try to fix the recurrence string if it's not a valid JSON array of strings, for example a bad input like "[\\\"RRULE:FREQ=YEARLY\\\"]"
+            recurrence_list = json.loads(fixed_recurrence)
+        except json.JSONDecodeError:
+            if _is_valid_recurrence_line_syntax(
+                recurrence
+            ):  # even if it's not a list,  check if it's a valid recurrence rule syntax, if yes, wrap it in a list
+                recurrence_list = [recurrence]
+            else:  # if it's not a valid recurrence rule syntax, raise an error
+                raise ValueError(
+                    f"Invalid recurrence list: {recurrence}. It must be a valid JSON array of strings, where each string is an RRULE, EXRULE, RDATE, or EXDATE line as defined by the RFC5545.."
+                )
+
+    for r in recurrence_list:
+        if not _is_valid_recurrence_line_syntax(r):
+            raise ValueError(
+                f"Invalid recurrence rule: {r}. It must be a valid RRULE, EXRULE, RDATE, or EXDATE string."
+            )
+
+    return recurrence_list
+
+
 def create_event(service):
     """Creates an event in the calendar."""
     calendar_id = os.getenv("CALENDAR_ID")
@@ -479,25 +520,9 @@ def create_event(service):
         },
     }
     recurrence = os.getenv("RECURRENCE")
-    if recurrence:
-        try:
-            recurrence_list = json.loads(recurrence)
-        except json.JSONDecodeError:
-            if _is_valid_recurrence_line_syntax(
-                recurrence
-            ):  # even if it's not a list,  check if it's a valid recurrence rule syntax, if yes, wrap it in a list
-                recurrence_list = [recurrence]
-            else:  # if it's not a valid recurrence rule syntax, raise an error
-                raise ValueError(
-                    f"Invalid recurrence list: {recurrence}. It must be a valid JSON array of strings, where each string is an RRULE, EXRULE, RDATE, or EXDATE line as defined by the RFC5545.."
-                )
 
-        for r in recurrence_list:
-            if not _is_valid_recurrence_line_syntax(r):
-                raise ValueError(
-                    f"Invalid recurrence rule: {r}. It must be a valid RRULE, EXRULE, RDATE, or EXDATE string."
-                )
-        event_body["recurrence"] = recurrence_list
+    if recurrence:
+        event_body["recurrence"] = _get_recurrence_list(recurrence)
 
     attendees = os.getenv(
         "ATTENDEES"
@@ -643,24 +668,7 @@ def update_event(service):
         if not _can_update_property(existing_event_type, "recurrence"):
             return return_field_update_error("recurrence", existing_event_type)
 
-        try:
-            recurrence_list = json.loads(recurrence)
-        except json.JSONDecodeError:
-            if _is_valid_recurrence_line_syntax(
-                recurrence
-            ):  # even if it's not a list,  check if it's a valid recurrence rule syntax, if yes, wrap it in a list
-                recurrence_list = [recurrence]
-            else:  # if it's not a valid recurrence rule syntax, raise an error
-                raise ValueError(
-                    f"Invalid recurrence list: {recurrence}. It must be a valid JSON array of strings, where each string is an RRULE, EXRULE, RDATE, or EXDATE line as defined by the RFC5545.."
-                )
-
-        for r in recurrence_list:
-            if not _is_valid_recurrence_line_syntax(r):
-                raise ValueError(
-                    f"Invalid recurrence rule: {r}. It must be a valid RRULE, EXRULE, RDATE, or EXDATE string."
-                )
-        event_body["recurrence"] = recurrence_list
+        event_body["recurrence"] = _get_recurrence_list(recurrence)
 
     add_attendees = os.getenv("ADD_ATTENDEES")
     replace_attendees = os.getenv("REPLACE_ATTENDEES")


### PR DESCRIPTION
- Update the prompt for Obot --  `json array of strings` instead of `json array`, reduce the possibility of LLM making mistakes. The LLM will now more likely to generate an array like `[ "RRULE:FREQ=YEARLY"]` instead of a string like `"[\"RRULE:FREQ=YEARLY\"]"`
- add one line of code to try to fix bad input.