### PR TITLE
Fix: remove PAT for slack bot tool, add permission to read message

### DIFF
--- a/slack/credential/bot.gpt
+++ b/slack/credential/bot.gpt
@@ -26,18 +26,8 @@ Tools: ../../oauth2
 			"chat:write",
 			"groups:write",
 			"mpim:write",
-			"im:write"
+			"im:write",
+			"app_mentions:read"
 		]
-	},
-	"promptInfo": {
-        "fields" : [
-            {
-                "name": "Slack API Key",
-                "description": "A Bot token for your Slack account.",
-                "sensitive": true,
-                "env": "SLACK_TOKEN"
-            }
-        ],
-        "message": "Enter your Slack User or Bot OAuth Token."
-    }
+	}
 }


### PR DESCRIPTION
We should only be requesting oauth for slack bot tool, as it is required to integrate with our existing slack integration. Also added permission to allow our app to read message event from the workspace.