### PR TITLE
Fix: fix python dependency

### DIFF
--- a/google/youtube/requirements.txt
+++ b/google/youtube/requirements.txt
@@ -14,7 +14,7 @@ pydantic_core==2.23.4
 requests==2.31.0
 sniffio==1.3.1
 tqdm==4.66.2
-typing_extensions==4.12.2
+typing_extensions==4.13.1
 urllib3==2.2.1
 youtube-transcript-api==0.6.2
 yt-dlp==2024.11.4


### PR DESCRIPTION
Fix mismatch dependency.

```
#31 114.9 ++ hash -r
#31 114.9 + find obot-tools -name requirements.txt -exec cat '{}' ';' -exec echo ';'
#31 114.9 + sort -u
#31 115.2 + uv pip install -r requirements.txt
#31 115.3 Using Python 3.13.2 environment at: obot-tools/venv
#31 115.5   × No solution found when resolving dependencies:
#31 115.5   ╰─▶ Because you require typing-extensions==4.12.2 and
#31 115.5       typing-extensions==4.13.1, we can conclude that your requirements are
#31 115.5       unsatisfiable.
```
https://github.com/obot-platform/obot/actions/runs/14250628637