### PR TITLE
fix: handle personal account type for Outlook Mail Groups

### DIFF
--- a/outlook/mail/pkg/commands/listGroups.go
+++ b/outlook/mail/pkg/commands/listGroups.go
@@ -20,9 +20,11 @@ func ListGroups(ctx context.Context) error {
 	groups, err := graph.ListGroups(ctx, c)
 	if err != nil {
 		userType, getUserTypeErr := graph.GetUserType(ctx, c)
-		if getUserTypeErr == nil && strings.EqualFold(userType, "Guest") {
-			fmt.Printf("User has type '%s', which does not have enough permissions to list groups.\n", userType)
-			return nil
+		if getUserTypeErr == nil {
+			if strings.EqualFold(userType, "Guest") || strings.EqualFold(userType, "Personal") { // Guest or Personal accounts don't have enough permissions to list groups
+				fmt.Printf("User has type '%s', which does not have enough permissions to list groups.\n", userType)
+				return nil
+			}
 		}
 		return fmt.Errorf("failed to list groups: %w", err)
 	}

--- a/outlook/mail/pkg/graph/group.go
+++ b/outlook/mail/pkg/graph/group.go
@@ -70,8 +70,8 @@ func GetUserType(ctx context.Context, client *msgraphsdkgo.GraphServiceClient) (
 	}
 
 	userType := me.GetUserType()
-	if userType == nil {
-		return "", fmt.Errorf("userType is nil in response")
+	if userType == nil { // Personal accounts don't have userType
+		return "Personal", nil
 	}
 
 	return *userType, nil


### PR DESCRIPTION
https://github.com/obot-platform/obot/issues/1940#issuecomment-2779420058
- When userType is `nil` it is a Personal Account
- which also doesn't have permission to the Group features.