### PR TITLE
Fix: fix slack permission typo

### DIFF
--- a/slack/credential/bot.gpt
+++ b/slack/credential/bot.gpt
@@ -28,7 +28,7 @@ Tools: ../../oauth2
 			"mpim:write",
 			"im:write",
 			"app_mentions:read",
-			"assistants:write"
+			"assistant:write"
 		]
 	}
 }


### PR DESCRIPTION
Fix a typo in slack permission