### PR TITLE
Fix: Add abilities to list other labels and select category

### DIFF
--- a/google/gmail/listInbox.py
+++ b/google/gmail/listInbox.py
@@ -8,7 +8,12 @@ async def main():
     max_results = os.getenv('MAX_RESULTS', '100')
     if max_results is not None:
         max_results = int(max_results)
-    query = 'label:inbox'
+    category = os.getenv('CATEGORY', 'primary')
+    label = os.getenv('LABEL', 'inbox')
+    if label != 'inbox':
+        query = f'label:{label}'
+    else:
+        query = f'label:{label} category:{category}'
 
     service = client('gmail', 'v1')
     await list_messages(service, query, max_results)

--- a/google/gmail/tool.gpt
+++ b/google/gmail/tool.gpt
@@ -17,6 +17,8 @@ Description: List emails in the user's Gmail inbox
 Credential: ../credential
 Share Contexts: Email List Context
 Tools: github.com/gptscript-ai/datasets/filter
+Param: label: The label of the inbox to list, options are 'inbox', 'starred', 'important', 'sent', 'drafts', 'trash', 'spam', 'all'. (Optional: Default is 'inbox')
+Param: category: The category of emails to list, options are 'primary', 'social', 'promotions', 'updates', 'forums'. (Optional: Default is 'primary')
 Param: max_results: Maximum number of emails to list (Optional: Default will list 100 emails in the inbox)
 
 #!/usr/bin/env python3 ${GPTSCRIPT_TOOL_DIR}/listInbox.py


### PR DESCRIPTION
Add abilities to list primary tab from gmail by default. Also add abilities to list other labels, like sent, trash, spam.