### PR TITLE
chore: add capability category back to database tool

### DIFF
--- a/database/tool.gpt
+++ b/database/tool.gpt
@@ -1,6 +1,7 @@
 ---
 Name: Database
 Description: Tools for interacting with a database
+Metadata: category: Capability
 Metadata: icon: https://cdn.jsdelivr.net/npm/@phosphor-icons/core@2/assets/duotone/database-duotone.svg
 Share Tools: Run Database SQL
 


### PR DESCRIPTION
Requires merge of capability tools update in admin-ui first: https://github.com/obot-platform/obot/pull/2575
Addresses [#2090](https://github.com/obot-platform/obot/issues/2090)