### PR TITLE
fix: outlook mail: use datasets where needed, fix date filters

### DIFF
--- a/outlook/mail/pkg/commands/listGroupThreads.go
+++ b/outlook/mail/pkg/commands/listGroupThreads.go
@@ -4,15 +4,16 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"time"
 
+	md "github.com/JohannesKaufmann/html-to-markdown"
+	"github.com/gptscript-ai/go-gptscript"
 	"github.com/gptscript-ai/tools/outlook/mail/pkg/client"
 	"github.com/gptscript-ai/tools/outlook/mail/pkg/global"
 	"github.com/gptscript-ai/tools/outlook/mail/pkg/graph"
 	"github.com/gptscript-ai/tools/outlook/mail/pkg/util"
-	md "github.com/JohannesKaufmann/html-to-markdown"
+	"github.com/microsoftgraph/msgraph-sdk-go/models"
 )
-
-
 
 func ListGroupThreads(ctx context.Context, groupID, start, end, limit string) error {
 	var (
@@ -38,71 +39,139 @@ func ListGroupThreads(ctx context.Context, groupID, start, end, limit string) er
 		return fmt.Errorf("failed to create client: %w", err)
 	}
 
-	threads, err := graph.ListGroupThreads(ctx, c, groupID, start, end, limitInt)
+	threads, err := graph.ListGroupThreads(ctx, c, groupID, limitInt)
 	if err != nil {
 		return fmt.Errorf("failed to list group threads: %w", err)
 	}
 
+	if len(threads) == 0 {
+		fmt.Println("No threads found")
+		return nil
+	}
+
+	if start != "" || end != "" {
+		threads, err = filterThreadsByTimeFrame(threads, start, end)
+		if err != nil {
+			return fmt.Errorf("failed to filter threads by time frame: %w", err)
+		}
+
+		if len(threads) == 0 {
+			fmt.Println("No threads found within specified time frame")
+			return nil
+		}
+	}
+
+	gptscriptClient, err := gptscript.NewGPTScript()
+	if err != nil {
+		return fmt.Errorf("failed to create GPTScript client: %w", err)
+	}
+
+	var (
+		elements  []gptscript.DatasetElement
+		converter = md.NewConverter("", true, nil)
+	)
+
 	for _, thread := range threads {
 		threadID := util.Deref(thread.GetId())
-
-		fmt.Printf("📩 Thread ID: %s\n", threadID)
-		if thread.GetTopic() != nil {
-			fmt.Printf("📌 Subject: %s\n", util.Deref(thread.GetTopic()))
-		} else {
-			fmt.Println("📌 Subject: (No Subject)")
+		threadSubject := util.Deref(thread.GetTopic())
+		if threadSubject == "" {
+			threadSubject = "(No Subject)"
 		}
-		fmt.Printf("📅 Last Delivered: %s\n", thread.GetLastDeliveredDateTime().String())
 
-		// Print unique senders
+		// Build thread content string
+		var threadContent string
+		threadContent += fmt.Sprintf("Thread ID: %s\n", threadID)
+		threadContent += fmt.Sprintf("Subject: %s\n", threadSubject)
+		threadContent += fmt.Sprintf("Last Delivered: %s\n", thread.GetLastDeliveredDateTime().String())
+
+		// Add unique senders
 		senders := thread.GetUniqueSenders()
-		fmt.Print("👥 Unique Senders: ")
-		for _, sender := range senders {
-			fmt.Printf("%s, ", sender) 
-		}
-		fmt.Println()
+		threadContent += "Unique Senders: " + util.JoinStrings(senders, ", ") + "\n\n"
 
-		// Fetch posts (individual emails/messages) inside the thread and then print them
+		// Fetch and add messages
 		posts, err := graph.ListThreadMessages(ctx, c, groupID, threadID)
 		if err != nil {
 			return fmt.Errorf("failed to list thread messages: %w", err)
 		}
 
-		fmt.Println("\n✉️ Messages:")
+		threadContent += "Messages:\n"
 		for i, post := range posts {
 			messageID := util.Deref(post.GetId())
-			fmt.Printf("📧 Message %d, ID: %s\n", i+1, messageID)
+			threadContent += fmt.Sprintf("\nMessage %d (ID: %s)\n", i+1, messageID)
 
-			// Check if sender information is available
 			if post.GetFrom() != nil && post.GetFrom().GetEmailAddress() != nil {
-				fmt.Printf("👤 From: %s <%s>\n",
+				threadContent += fmt.Sprintf("From: %s <%s>\n",
 					util.Deref(post.GetFrom().GetEmailAddress().GetName()),
 					util.Deref(post.GetFrom().GetEmailAddress().GetAddress()),
 				)
 			} else {
-				fmt.Println("👤 Sender: Unknown")
+				threadContent += "From: Unknown\n"
 			}
 
-			fmt.Printf("📅 Sent: %s\n", post.GetReceivedDateTime().String())
+			threadContent += fmt.Sprintf("Sent: %s\n", post.GetReceivedDateTime().String())
 
-			// Print message body if available
 			if post.GetBody() != nil && post.GetBody().GetContent() != nil {
-				fmt.Println("📝 Message Body:")
-				converter := md.NewConverter("", true, nil)
 				bodyHTML := util.Deref(post.GetBody().GetContent())
 				bodyMarkdown, err := converter.ConvertString(bodyHTML)
 				if err != nil {
 					return fmt.Errorf("failed to convert email body HTML to markdown: %w", err)
 				}
-				fmt.Println(bodyMarkdown)
-
+				threadContent += fmt.Sprintf("Body:\n%s\n", bodyMarkdown)
 			} else {
-				fmt.Println("📭 (No content in this message)")
+				threadContent += "(No content in this message)\n"
 			}
-			fmt.Println()
 		}
 
-		fmt.Println("\n")
+		elements = append(elements, gptscript.DatasetElement{
+			DatasetElementMeta: gptscript.DatasetElementMeta{
+				Name:        threadID,
+				Description: threadSubject,
+			},
+			Contents: threadContent,
+		})
 	}
+
+	datasetID, err := gptscriptClient.CreateDatasetWithElements(ctx, elements, gptscript.DatasetOptions{
+		Name:        fmt.Sprintf("outlook_group_%s_threads", groupID),
+		Description: fmt.Sprintf("Threads from Outlook group %s", groupID),
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create dataset: %w", err)
+	}
+
+	fmt.Printf("Created dataset with ID %s with %d threads\n", datasetID, len(elements))
 	return nil
-} 
+}
+
+func filterThreadsByTimeFrame(threads []models.ConversationThreadable, start, end string) ([]models.ConversationThreadable, error) {
+	var (
+		startTime time.Time
+		endTime   time.Time
+		err       error
+	)
+	if start != "" {
+		startTime, err = time.Parse(time.RFC3339, start)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse start date: %w", err)
+		}
+	}
+	if end != "" {
+		endTime, err = time.Parse(time.RFC3339, end)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse end date: %w", err)
+		}
+	}
+
+	var filteredThreads []models.ConversationThreadable
+	for _, thread := range threads {
+		if start != "" && thread.GetLastDeliveredDateTime().Before(startTime) {
+			continue
+		}
+		if end != "" && thread.GetLastDeliveredDateTime().After(endTime) {
+			continue
+		}
+		filteredThreads = append(filteredThreads, thread)
+	}
+
+	return filteredThreads, nil
+}

--- a/outlook/mail/pkg/commands/listGroupThreads.go
+++ b/outlook/mail/pkg/commands/listGroupThreads.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 
 	md "github.com/JohannesKaufmann/html-to-markdown"
@@ -86,7 +87,7 @@ func ListGroupThreads(ctx context.Context, groupID, start, end, limit string) er
 
 		// Add unique senders
 		senders := thread.GetUniqueSenders()
-		threadContent += "Unique Senders: " + util.JoinStrings(senders, ", ") + "\n\n"
+		threadContent += "Unique Senders: " + strings.Join(senders, ", ") + "\n\n"
 
 		// Fetch and add messages
 		posts, err := graph.ListThreadMessages(ctx, c, groupID, threadID)

--- a/outlook/mail/pkg/util/util.go
+++ b/outlook/mail/pkg/util/util.go
@@ -1,7 +1,5 @@
 package util
 
-import "strings"
-
 func Ptr[T any](v T) *T {
 	return &v
 }
@@ -29,9 +27,4 @@ func Filter[T any](arr []T, f func(T) bool) []T {
 		}
 	}
 	return out
-}
-
-// JoinStrings joins a slice of strings with the given separator
-func JoinStrings(strs []string, sep string) string {
-	return strings.Join(strs, sep)
 }

--- a/outlook/mail/pkg/util/util.go
+++ b/outlook/mail/pkg/util/util.go
@@ -1,5 +1,7 @@
 package util
 
+import "strings"
+
 func Ptr[T any](v T) *T {
 	return &v
 }
@@ -27,4 +29,9 @@ func Filter[T any](arr []T, f func(T) bool) []T {
 		}
 	}
 	return out
+}
+
+// JoinStrings joins a slice of strings with the given separator
+func JoinStrings(strs []string, sep string) string {
+	return strings.Join(strs, sep)
 }

--- a/outlook/mail/tool.gpt
+++ b/outlook/mail/tool.gpt
@@ -175,6 +175,7 @@ Param: thread_id: The ID of the thread to delete.
 Name: List Groups
 Description: Lists all groups the user is a member of.
 Share Context: Outlook Mail Context
+Tools: github.com/gptscript-ai/datasets/filter
 Credential: ./credential
 
 #!${GPTSCRIPT_TOOL_DIR}/bin/gptscript-go-tool listGroups
@@ -183,6 +184,7 @@ Credential: ./credential
 Name: List Group Threads
 Description: Lists all group mailbox threads in a Microsoft 365 group. This will also return messages in the threads.
 Share Context: Outlook Mail Context
+Tools: github.com/gptscript-ai/datasets/filter
 Credential: ./credential
 Share Tools: List Groups
 Param: group_id: The ID of the group to list threads in.


### PR DESCRIPTION
I needed datasets here for a use case I am working on, so I added them. I also fixed an issue around listing group emails, because the Graph API does not let you filter by start and end for that API method, so we have to filter after instead.