### PR TITLE
feat: Gmail support CRUD labels and support apply/remove labels to emails

### DIFF
--- a/google/gmail/apis/helpers.py
+++ b/google/gmail/apis/helpers.py
@@ -87,7 +87,6 @@ def extract_message_headers(message):
     date = None
 
     if message is not None:
-        # label_ids = [l for l in message.get("labelIds", []) if not l.startswith("CATEGORY_")]
         label_ids = message.get("labelIds", [])
 
         for header in message["payload"]["headers"]:

--- a/google/gmail/apis/helpers.py
+++ b/google/gmail/apis/helpers.py
@@ -72,6 +72,9 @@ def extract_message_headers(message):
     date = None
 
     if message is not None:
+        # label_ids = [l for l in message.get("labelIds", []) if not l.startswith("CATEGORY_")]
+        label_ids = message.get("labelIds", [])
+
         for header in message["payload"]["headers"]:
             match header["name"].lower():
                 case "subject":
@@ -90,7 +93,7 @@ def extract_message_headers(message):
             .strftime("%Y-%m-%d %H:%M:%S %Z")
         )
 
-    return subject, sender, to, cc, bcc, date
+    return subject, sender, to, cc, bcc, date, label_ids
 
 
 async def prepend_base_path(base_path: str, file_path: str):
@@ -155,3 +158,8 @@ def format_query_timestamp(time_str: str):
 
     except ValueError as e:
         raise ValueError(f"Invalid datetime format: {e}")
+
+
+def str_to_bool(value):
+    """Convert a string to a boolean."""
+    return str(value).lower() in ("true", "1", "yes")

--- a/google/gmail/apis/helpers.py
+++ b/google/gmail/apis/helpers.py
@@ -35,6 +35,21 @@ def setup_logger(name):
 logger = setup_logger(__name__)
 
 
+GMAIL_BUILTIN_LABELS = {
+    "INBOX", "SPAM", "TRASH", "DRAFT", "SENT", "IMPORTANT", "STARRED", "UNREAD", "CATEGORY_PERSONAL",
+    "CATEGORY_SOCIAL", "CATEGORY_PROMOTIONS", "CATEGORY_UPDATES", "CATEGORY_FORUMS"
+}
+
+def parse_label_ids(label_ids_input: str) -> list[str]:
+    label_ids = []
+    for label in label_ids_input.split(","):
+        label = label.strip()
+        if label.upper() in GMAIL_BUILTIN_LABELS:
+            label_ids.append(label.upper())
+        else:
+            label_ids.append(label)  # preserve custom labels
+    return label_ids
+
 def get_user_timezone():
     user_tz = os.getenv("OBOT_USER_TIMEZONE", "UTC").strip()
 

--- a/google/gmail/apis/labels.py
+++ b/google/gmail/apis/labels.py
@@ -1,0 +1,43 @@
+def list_labels(service):
+    response = service.users().labels().list(userId="me").execute()
+    return response.get("labels", [])
+
+
+def get_label(service, label_id):
+    return service.users().labels().get(userId="me", id=label_id).execute()
+
+
+def create_label(
+    service, name, label_list_visibility="labelShow", message_list_visibility="show"
+):
+    label = {
+        "name": name,
+        "labelListVisibility": label_list_visibility,
+        "messageListVisibility": message_list_visibility,
+    }
+    return service.users().labels().create(userId="me", body=label).execute()
+
+
+def update_label(
+    service,
+    label_id,
+    name=None,
+    label_list_visibility=None,
+    message_list_visibility=None,
+):
+    label = {"id": label_id}
+    if name:
+        label["name"] = name
+    if label_list_visibility:
+        label["labelListVisibility"] = label_list_visibility
+    if message_list_visibility:
+        label["messageListVisibility"] = message_list_visibility
+
+    return (
+        service.users().labels().update(userId="me", id=label_id, body=label).execute()
+    )
+
+
+def delete_label(service, label_id):
+    service.users().labels().delete(userId="me", id=label_id).execute()
+    return f"Label {label_id} deleted successfully."

--- a/google/gmail/apis/labels.py
+++ b/google/gmail/apis/labels.py
@@ -1,10 +1,24 @@
+import googleapiclient.errors # Add import for potential API errors
+
 def list_labels(service):
-    response = service.users().labels().list(userId="me").execute()
-    return response.get("labels", [])
+    try:
+        response = service.users().labels().list(userId="me").execute()
+        return response.get("labels", [])
+    except googleapiclient.errors.HttpError as e:
+        # Re-raise the specific API error or a custom exception
+        raise Exception(f"An error occurred listing labels: {e}") from e
+    except Exception as e:
+        # Catch other potential exceptions
+        raise Exception(f"An unexpected error occurred listing labels: {e}") from e
 
 
 def get_label(service, label_id):
-    return service.users().labels().get(userId="me", id=label_id).execute()
+    try:
+        return service.users().labels().get(userId="me", id=label_id).execute()
+    except googleapiclient.errors.HttpError as e:
+        raise Exception(f"An error occurred getting label {label_id}: {e}") from e
+    except Exception as e:
+        raise Exception(f"An unexpected error occurred getting label {label_id}: {e}") from e
 
 
 def create_label(
@@ -15,7 +29,12 @@ def create_label(
         "labelListVisibility": label_list_visibility,
         "messageListVisibility": message_list_visibility,
     }
-    return service.users().labels().create(userId="me", body=label).execute()
+    try:
+        return service.users().labels().create(userId="me", body=label).execute()
+    except googleapiclient.errors.HttpError as e:
+        raise Exception(f"An error occurred creating label '{name}': {e}") from e
+    except Exception as e:
+        raise Exception(f"An unexpected error occurred creating label '{name}': {e}") from e
 
 
 def update_label(
@@ -33,11 +52,21 @@ def update_label(
     if message_list_visibility:
         label["messageListVisibility"] = message_list_visibility
 
-    return (
-        service.users().labels().update(userId="me", id=label_id, body=label).execute()
-    )
+    try:
+        return (
+            service.users().labels().update(userId="me", id=label_id, body=label).execute()
+        )
+    except googleapiclient.errors.HttpError as e:
+        raise Exception(f"An error occurred updating label {label_id}: {e}") from e
+    except Exception as e:
+        raise Exception(f"An unexpected error occurred updating label {label_id}: {e}") from e
 
 
 def delete_label(service, label_id):
-    service.users().labels().delete(userId="me", id=label_id).execute()
-    return f"Label {label_id} deleted successfully."
+    try:
+        service.users().labels().delete(userId="me", id=label_id).execute()
+        return f"Label {label_id} deleted successfully."
+    except googleapiclient.errors.HttpError as e:
+        raise Exception(f"An error occurred deleting label {label_id}: {e}") from e
+    except Exception as e:
+        raise Exception(f"An unexpected error occurred deleting label {label_id}: {e}") from e

--- a/google/gmail/apis/messages.py
+++ b/google/gmail/apis/messages.py
@@ -99,7 +99,7 @@ def modify_message_labels(
         raise ValueError(f"Conflicting labelIds in add and remove: {conflict_labels}")
 
     if not add_labels and not remove_labels:
-        print(f"Warning: No labels to modify for message {message_id}")
+        raise ValueError(f"Warning: No labels to modify for message {message_id}")
 
     body = {
         "addLabelIds": list(add_labels),

--- a/google/gmail/apis/messages.py
+++ b/google/gmail/apis/messages.py
@@ -4,6 +4,7 @@ from email import encoders
 from email.mime.base import MIMEBase
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
+from typing import Optional
 
 import gptscript
 from bs4 import BeautifulSoup
@@ -11,9 +12,106 @@ from filetype import guess_mime
 from googleapiclient.errors import HttpError
 from gptscript.datasets import DatasetElement
 
-from apis.helpers import format_query_timestamp, extract_message_headers, prepend_base_path, setup_logger
+from apis.helpers import (
+    format_query_timestamp,
+    extract_message_headers,
+    prepend_base_path,
+    setup_logger,
+)
 
 logger = setup_logger(__name__)
+
+
+def modify_message_labels(
+    service,
+    message_id,
+    add_labels=None,
+    remove_labels=None,
+    archive: Optional[
+        bool
+    ] = None,  # True = remove 'INBOX', False = add 'INBOX', None = leave unchanged
+    mark_as_read: Optional[
+        bool
+    ] = None,  # True = read, False = unread, None = leave unchanged
+    mark_as_starred: Optional[
+        bool
+    ] = None,  # True = star, False = unstar, None = leave unchanged
+    mark_as_important: Optional[
+        bool
+    ] = None,  # True = important, False = not important, None = leave unchanged
+):
+    add_labels = set(add_labels or [])
+    remove_labels = set(remove_labels or [])
+
+    # Validate UNREAD usage with mark_as_read
+    if mark_as_read is not None and (
+        "UNREAD" in add_labels or "UNREAD" in remove_labels
+    ):
+        raise ValueError(
+            "Do not include 'UNREAD' in add_labels/remove_labels when using mark_as_read"
+        )
+
+    # Validate INBOX usage with archive
+    if archive is not None and ("INBOX" in add_labels or "INBOX" in remove_labels):
+        raise ValueError(
+            "Do not include 'INBOX' in add_labels/remove_labels when using archive flag"
+        )
+
+    if mark_as_starred is not None and (
+        "STARRED" in add_labels or "STARRED" in remove_labels
+    ):
+        raise ValueError(
+            "Do not include 'STARRED' in add_labels/remove_labels when using mark_as_starred"
+        )
+
+    if mark_as_important is not None and (
+        "IMPORTANT" in add_labels or "IMPORTANT" in remove_labels
+    ):
+        raise ValueError(
+            "Do not include 'IMPORTANT' in add_labels/remove_labels when using mark_as_important"
+        )
+
+    # Apply archive behavior
+    if archive is True:
+        remove_labels.add("INBOX")
+    elif archive is False:
+        add_labels.add("INBOX")
+
+    # Apply read/unread behavior
+    if mark_as_read is True:
+        remove_labels.add("UNREAD")
+    elif mark_as_read is False:
+        add_labels.add("UNREAD")
+
+    if mark_as_starred is True:
+        add_labels.add("STARRED")
+    elif mark_as_starred is False:
+        remove_labels.add("STARRED")
+
+    if mark_as_important is True:
+        add_labels.add("IMPORTANT")
+    elif mark_as_important is False:
+        remove_labels.add("IMPORTANT")
+
+    # Optional: fail on conflicting labels
+    conflict_labels = add_labels & remove_labels
+    if conflict_labels:
+        raise ValueError(f"Conflicting labelIds in add and remove: {conflict_labels}")
+
+    if not add_labels and not remove_labels:
+        print(f"Warning: No labels to modify for message {message_id}")
+
+    body = {
+        "addLabelIds": list(add_labels),
+        "removeLabelIds": list(remove_labels),
+    }
+
+    return (
+        service.users()
+        .messages()
+        .modify(userId="me", id=message_id, body=body)
+        .execute()
+    )
 
 
 async def create_message(
@@ -167,7 +265,7 @@ async def list_messages(
         dataset_id = await gptscript_client.add_dataset_elements(
             elements,
             name=f"gmail_{query}",
-            description=f"list of emails in Gmail for query {query}",
+            description=f"list of emails in Gmail for query: [{query}], labels: [{labels}]",
         )
 
         print(f"Created dataset with ID {dataset_id} with {len(elements)} emails")
@@ -188,10 +286,10 @@ def message_to_string(service, message):
         .execute()
     )
     msg_id = msg["id"]
-    subject, sender, to, cc, bcc, date = extract_message_headers(msg)
+    subject, sender, to, cc, bcc, date, label_ids = extract_message_headers(msg)
     return (
         msg_id,
-        f"ID: {msg_id} From: {sender}, Subject: {subject}, To: {to}, CC: {cc}, Bcc: {bcc}, Received: {date}",
+        f"ID: {msg_id} From: {sender}, Subject: {subject}, To: {to}, CC: {cc}, Bcc: {bcc}, Received: {date}, Labels: {label_ids}",
     )
 
 

--- a/google/gmail/commands/__init__.py
+++ b/google/gmail/commands/__init__.py
@@ -1,0 +1,6 @@
+from commands.list_emails import list_emails_tool
+from commands.list_labels import list_labels_tool
+from commands.create_label import create_label_tool
+from commands.update_label import update_label_tool
+from commands.delete_label import delete_label_tool
+from commands.modify_message_labels import modify_message_labels_tool

--- a/google/gmail/commands/create_label.py
+++ b/google/gmail/commands/create_label.py
@@ -1,0 +1,29 @@
+import os
+from apis.labels import create_label
+from apis.helpers import client
+
+
+def create_label_tool():
+    service = client("gmail", "v1")
+    label_name = os.getenv("LABEL_NAME")
+    if not label_name:
+        print(f"Error: LABEL_NAME is required and is not set")
+        return
+    label_list_visibility = os.getenv("LABEL_LIST_VISIBILITY", "labelShow")
+    valid_label_list_visibilities = ["labelShow", "labelHide", "labelShowIfUnread"]
+    if label_list_visibility not in valid_label_list_visibilities:
+        print(
+            f"Error: invalid value for LABEL_LIST_VISIBILITY: {label_list_visibility}. Must be one of {valid_label_list_visibilities}"
+        )
+        return
+    message_list_visibility = os.getenv("MESSAGE_LIST_VISIBILITY", "show")
+    valid_message_list_visibilities = ["show", "hide"]
+    if message_list_visibility not in valid_message_list_visibilities:
+        print(
+            f"Error: invalid value for MESSAGE_LIST_VISIBILITY: {message_list_visibility}. Must be one of {valid_message_list_visibilities}"
+        )
+        return
+    label = create_label(
+        service, label_name, label_list_visibility, message_list_visibility
+    )
+    print(f"Label created: {label}")

--- a/google/gmail/commands/delete_label.py
+++ b/google/gmail/commands/delete_label.py
@@ -1,0 +1,13 @@
+import os
+from apis.labels import delete_label
+from apis.helpers import client
+
+
+def delete_label_tool():
+    service = client("gmail", "v1")
+    label_id = os.getenv("LABEL_ID")
+    if not label_id:
+        print(f"Error: LABEL_ID is required and is not set")
+        return
+    label = delete_label(service, label_id)
+    print(f"Label deleted: {label}")

--- a/google/gmail/commands/list_emails.py
+++ b/google/gmail/commands/list_emails.py
@@ -1,10 +1,8 @@
-import asyncio
 import os
 import sys
 
-from apis.helpers import client
+from apis.helpers import client, parse_label_ids
 from apis.messages import list_messages
-
 
 async def list_emails_tool():
     max_results = os.getenv("MAX_RESULTS", "100")
@@ -23,16 +21,14 @@ async def list_emails_tool():
     default_inbox = "INBOX"
     if query != "":
         default_inbox = ""  # if query is not empty, don't set inbox as default
-    labels = os.getenv("LABELS", default_inbox)
+    labels = os.getenv("LABEL_IDS", default_inbox)
     category = os.getenv("CATEGORY", "primary")
     valid_categories = ["primary", "social", "promotions", "updates", "forums"]
     if category not in valid_categories:
         print(f"Invalid category: {category}. Valid categories are: {valid_categories}")
         sys.exit(1)
 
-    label_ids = [
-        label.strip().upper() for label in labels.split(",") if label.strip() != ""
-    ]
+    label_ids = parse_label_ids(labels)
     if "ALL" in label_ids:
         label_ids = []
     elif "INBOX" in label_ids:

--- a/google/gmail/commands/list_emails.py
+++ b/google/gmail/commands/list_emails.py
@@ -1,0 +1,45 @@
+import asyncio
+import os
+import sys
+
+from apis.helpers import client
+from apis.messages import list_messages
+
+
+async def list_emails_tool():
+    max_results = os.getenv("MAX_RESULTS", "100")
+    if max_results.isdigit():
+        max_results = int(max_results)
+    else:
+        print(f"Invalid max_results: {max_results}. Must be a positive integer.")
+        sys.exit(1)
+
+    query = os.getenv("QUERY", "")
+    if "after:" in query or "before:" in query:
+        print(
+            "Error: Please use the parameters `after` and `before` instead of having them in the `query`."
+        )
+        sys.exit(1)
+    default_inbox = "INBOX"
+    if query != "":
+        default_inbox = ""  # if query is not empty, don't set inbox as default
+    labels = os.getenv("LABELS", default_inbox)
+    category = os.getenv("CATEGORY", "primary")
+    valid_categories = ["primary", "social", "promotions", "updates", "forums"]
+    if category not in valid_categories:
+        print(f"Invalid category: {category}. Valid categories are: {valid_categories}")
+        sys.exit(1)
+
+    label_ids = [
+        label.strip().upper() for label in labels.split(",") if label.strip() != ""
+    ]
+    if "ALL" in label_ids:
+        label_ids = []
+    elif "INBOX" in label_ids:
+        query = f"{query} category:{category.lower()}"
+
+    after = os.getenv("AFTER", "")
+    before = os.getenv("BEFORE", "")
+
+    service = client("gmail", "v1")
+    await list_messages(service, query, label_ids, max_results, after, before)

--- a/google/gmail/commands/list_labels.py
+++ b/google/gmail/commands/list_labels.py
@@ -1,0 +1,18 @@
+import os
+from apis.labels import list_labels, get_label
+from apis.helpers import client
+
+
+def list_labels_tool():
+    label_id = os.getenv("LABEL_ID", None)
+    service = client("gmail", "v1")
+
+    if label_id:  # get a specific label if label_id is provided
+        label = get_label(service, label_id)
+        print(f"Label: {label}")
+    else:
+        labels = list_labels(service)
+        custom_labels = [
+            l for l in labels if l.get("type") == "user"
+        ]  # only show custom labels
+        print(f"Custom labels: {custom_labels}")

--- a/google/gmail/commands/modify_message_labels.py
+++ b/google/gmail/commands/modify_message_labels.py
@@ -1,25 +1,20 @@
 import os
 import sys
 from apis.messages import modify_message_labels
-from apis.helpers import client, str_to_bool
-
+from apis.helpers import client, str_to_bool, parse_label_ids
 
 def modify_message_labels_tool():
-    message_id = os.getenv("MESSAGE_ID")
-    if not message_id:
-        print(f"required environment variable MESSAGE_ID not set")
+    email_id = os.getenv("EMAIL_ID")
+    if not email_id:
+        print(f"required environment variable EMAIL_ID not set")
         sys.exit(1)
 
-    add_labels = os.getenv("ADD_LABELS", None)
+    add_labels = os.getenv("ADD_LABEL_IDS", None)
     if add_labels:
-        add_labels = add_labels.upper().split(
-            ","
-        )  # convert to uppercase and split by comma for label_ids
-    remove_labels = os.getenv("REMOVE_LABELS", None)
+        add_labels = parse_label_ids(add_labels)
+    remove_labels = os.getenv("REMOVE_LABEL_IDS", None)
     if remove_labels:
-        remove_labels = remove_labels.upper().split(
-            ","
-        )  # convert to uppercase and split by comma for label_ids
+        remove_labels = parse_label_ids(remove_labels)
 
     env_flags = {
         "archive": "ARCHIVE",
@@ -42,7 +37,7 @@ def modify_message_labels_tool():
     service = client()
     res = modify_message_labels(
         service,
-        message_id,
+        email_id,
         add_labels,
         remove_labels,
         archive,

--- a/google/gmail/commands/modify_message_labels.py
+++ b/google/gmail/commands/modify_message_labels.py
@@ -1,0 +1,53 @@
+import os
+import sys
+from apis.messages import modify_message_labels
+from apis.helpers import client, str_to_bool
+
+
+def modify_message_labels_tool():
+    message_id = os.getenv("MESSAGE_ID")
+    if not message_id:
+        print(f"required environment variable MESSAGE_ID not set")
+        sys.exit(1)
+
+    add_labels = os.getenv("ADD_LABELS", None)
+    if add_labels:
+        add_labels = add_labels.upper().split(
+            ","
+        )  # convert to uppercase and split by comma for label_ids
+    remove_labels = os.getenv("REMOVE_LABELS", None)
+    if remove_labels:
+        remove_labels = remove_labels.upper().split(
+            ","
+        )  # convert to uppercase and split by comma for label_ids
+
+    env_flags = {
+        "archive": "ARCHIVE",
+        "mark_as_read": "MARK_AS_READ",
+        "mark_as_starred": "MARK_AS_STARRED",
+        "mark_as_important": "MARK_AS_IMPORTANT"
+    }
+
+    parsed_flags = {
+        key: str_to_bool(os.getenv(env_key)) if os.getenv(env_key) is not None else None
+        for key, env_key in env_flags.items()
+    }
+
+    # Unpack if needed
+    archive = parsed_flags["archive"]
+    mark_as_read = parsed_flags["mark_as_read"]
+    mark_as_starred = parsed_flags["mark_as_starred"]
+    mark_as_important = parsed_flags["mark_as_important"]
+
+    service = client()
+    res = modify_message_labels(
+        service,
+        message_id,
+        add_labels,
+        remove_labels,
+        archive,
+        mark_as_read,
+        mark_as_starred,
+        mark_as_important,
+    )
+    print(res)

--- a/google/gmail/commands/update_label.py
+++ b/google/gmail/commands/update_label.py
@@ -31,6 +31,6 @@ def update_label_tool():
         )
         return
     label = update_label(
-        service, label_name, label_list_visibility, message_list_visibility
+        service, label_id, label_name, label_list_visibility, message_list_visibility
     )
     print(f"Label updated: {label}")

--- a/google/gmail/commands/update_label.py
+++ b/google/gmail/commands/update_label.py
@@ -1,0 +1,36 @@
+import os
+from apis.labels import update_label
+from apis.helpers import client
+
+
+def update_label_tool():
+    service = client("gmail", "v1")
+    label_id = os.getenv("LABEL_ID")
+    if not label_id:
+        print(f"Error: LABEL_ID is required and is not set")
+        return
+    label_name = os.getenv("LABEL_NAME")
+    label_list_visibility = os.getenv("LABEL_LIST_VISIBILITY")
+    valid_label_list_visibilities = ["labelShow", "labelHide", "labelShowIfUnread"]
+    if (
+        label_list_visibility
+        and label_list_visibility not in valid_label_list_visibilities
+    ):
+        print(
+            f"Error: invalid value for LABEL_LIST_VISIBILITY: {label_list_visibility}. Must be one of {valid_label_list_visibilities}"
+        )
+        return
+    message_list_visibility = os.getenv("MESSAGE_LIST_VISIBILITY")
+    valid_message_list_visibilities = ["show", "hide"]
+    if (
+        message_list_visibility
+        and message_list_visibility not in valid_message_list_visibilities
+    ):
+        print(
+            f"Error: invalid value for MESSAGE_LIST_VISIBILITY: {message_list_visibility}. Must be one of {valid_message_list_visibilities}"
+        )
+        return
+    label = update_label(
+        service, label_name, label_list_visibility, message_list_visibility
+    )
+    print(f"Label updated: {label}")

--- a/google/gmail/main.py
+++ b/google/gmail/main.py
@@ -1,0 +1,44 @@
+import sys
+import asyncio
+from commands import (
+    list_emails_tool,
+    list_labels_tool,
+    create_label_tool,
+    update_label_tool,
+    delete_label_tool,
+    modify_message_labels_tool,
+)
+
+
+async def main():
+
+    if len(sys.argv) != 2:
+        print(
+            f"Error running command: {' '.join(sys.argv)} \nUsage: python3 main.py <command>"
+        )
+        sys.exit(1)
+
+    command = sys.argv[1]
+    try:
+        match command:
+            case "list_emails":
+                await list_emails_tool()
+            case "create_label":
+                create_label_tool()
+            case "list_labels":
+                list_labels_tool()
+            case "update_label":
+                update_label_tool()
+            case "delete_label":
+                delete_label_tool()
+            case "modify_message_labels":
+                modify_message_labels_tool()
+            case _:
+                print(f"Command {command} not found")
+    except Exception as e:
+        print(f"Error running command: {' '.join(sys.argv)} \nError: {e}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/google/gmail/readEmail.py
+++ b/google/gmail/readEmail.py
@@ -31,10 +31,10 @@ def main():
         body = get_email_body(msg)
         attachment = has_attachment(msg)
 
-        subject, sender, to, cc, bcc, date = extract_message_headers(msg)
+        subject, sender, to, cc, bcc, date, labels = extract_message_headers(msg)
 
         print(
-            f"From: {sender}, Subject: {subject}, To: {to}, CC: {cc}, Bcc: {bcc}, Date: {date}"
+            f"From: {sender}, Subject: {subject}, To: {to}, CC: {cc}, Bcc: {bcc}, Date: {date}, Labels: {labels}"
         )
         print(f"Body:\n{body}")
         if attachment:

--- a/google/gmail/readEmail.py
+++ b/google/gmail/readEmail.py
@@ -5,12 +5,11 @@ from googleapiclient.errors import HttpError
 
 from apis.helpers import client
 from apis.messages import (
-    extract_message_headers,
     fetch_email_or_draft,
     get_email_body,
     has_attachment,
+    format_message_metadata,
 )
-
 
 def main():
     email_id = os.getenv("EMAIL_ID")
@@ -31,12 +30,9 @@ def main():
         body = get_email_body(msg)
         attachment = has_attachment(msg)
 
-        subject, sender, to, cc, bcc, date, labels = extract_message_headers(msg)
-
-        print(
-            f"From: {sender}, Subject: {subject}, To: {to}, CC: {cc}, Bcc: {bcc}, Date: {date}, Labels: {labels}"
-        )
-        print(f"Body:\n{body}")
+        _, metadata_str = format_message_metadata(msg)
+        print(f"Email metadata:\n{metadata_str}")
+        print(f"Email body:\n{body}")
         if attachment:
             print("Email has attachment(s)")
             link = "https://mail.google.com/mail/u/0/#inbox/" + email_id

--- a/google/gmail/tool.gpt
+++ b/google/gmail/tool.gpt
@@ -2,7 +2,7 @@
 Name: Gmail
 Description: Tools for interacting with a user's Gmail account
 Metadata: bundle: true
-Share Tools: Current Email, List Inbox, Read Email, Send Email, Delete Email, List Drafts, Create Draft, Update Draft, Delete Draft, Send Draft, List Attachments, Download Attachment, Read Attachment
+Share Tools: Current Email, List Emails, Read Email, Send Email, Delete Email, Modify Email Labels, List Drafts, Create Draft, Update Draft, Delete Draft, Send Draft, List Attachments, Download Attachment, Read Attachment, List Labels, Create Label, Update Label, Delete Label
 
 ---
 Name: Current Email
@@ -12,7 +12,7 @@ Credential: ../credential
 #!/usr/bin/env python3 ${GPTSCRIPT_TOOL_DIR}/currentEmail.py
 
 ---
-Name: List Inbox
+Name: List Emails
 Description: List emails in the user's Gmail account. By default, this will list emails in the inbox, but if any query is provided, it will list all emails that match the query. Supports filtering by labels, category, and query.
 Credential: ../credential
 Share Contexts: Email List Context
@@ -24,13 +24,13 @@ Param: before: (Optional) Return only emails received strictly **before** this t
 Param: query: (Optional) Search query in Gmail search syntax (e.g., "from:someuser@example.com rfc822msgid:<somemsgid@example.com> is:unread"). Don't use `before` or `after` in the query.
 Param: max_results: (Optional) Maximum number of emails to list, default is 100 
 
-#!/usr/bin/env python3 ${GPTSCRIPT_TOOL_DIR}/list_emails.py
+#!/usr/bin/env python3 ${GPTSCRIPT_TOOL_DIR}/main.py list_emails
 
 ---
 Name: Read Email
 Description: Read an email or draft from the user's Gmail account
 Credential: ../credential
-Share Tools: List Inbox, List Drafts
+Share Tools: List Emails, List Drafts
 Param: email_id: Email or Draft ID to read (Optional: If not provided, email_subject is required)
 Param: email_subject: Email subject to read (Optional: If not provided, email_id is required)
 
@@ -53,10 +53,27 @@ Param: message: Message body of the email.
 Name: Delete Email
 Description: Delete an email in a user's Gmail account.
 Credential: ../credential
-Share Tools: List Inbox
+Share Tools: List Emails
 Param: email_id: The ID of the email to delete
 
 #!/usr/bin/env python3 ${GPTSCRIPT_TOOL_DIR}/deleteEmail.py
+
+
+---
+Name: Modify Email Labels
+Description: Modify labels on a Gmail email. Supports marking an email as read or unread, archiving or unarchiving it, starring or unstarring it, marking it as important or not important, and adding or removing custom labels.
+Credential: ../credential
+Share Tools: List Emails
+Share Context: Modify Email Labels Context
+Param: email_id: (Required) The ID of the email to modify.
+Param: archive: (Optional) Set to true to archive the email (remove it from Inbox), or false to unarchive it (add back to Inbox). Default is None (no change).
+Param: mark_as_read: (Optional) Set to true to mark the email as read, or false to mark it as unread. Default is None (no change).
+Param: mark_as_starred: (Optional) Set to true to star the email, or false to remove the star. Default is None (no change).
+Param: mark_as_important: (Optional) Set to true to mark the email as important, or false to remove the important label. Default is None (no change).
+Param: add_labels: (Optional) A comma-separated list of custom label names to add to the email. Default is an empty list.
+Param: remove_labels: (Optional) A comma-separated list of custom label names to remove from the email. Default is an empty list.
+
+#!/usr/bin/env python3 ${GPTSCRIPT_TOOL_DIR}/main.py modify_message_labels
 
 ---
 Name: List Drafts
@@ -156,6 +173,24 @@ Param: attachment_id: The ID of the attachment to read
 #!/usr/bin/env python3 ${GPTSCRIPT_TOOL_DIR}/getAttachment.py
 
 ---
+Name: List Labels
+Description: List custom labels in a user's Gmail account. If label id is provided, it will return the metadata of the label with that id.
+Credential: ../credential
+Param: label_id: (Optional) The ID of the label to return. Default to empty string.
+
+#!/usr/bin/env python3 ${GPTSCRIPT_TOOL_DIR}/main.py list_labels
+
+---
+Name: Create Label
+Description: Create a custom label in a user's Gmail account.
+Credential: ../credential
+Param: label_name: The name of the label to create.
+Param: label_list_visibility: (Optional) This controls whether and how the label appears in the Gmail sidebar (left panel). Must be one of 'labelShow', 'labelHide', 'labelShowIfUnread', default is 'labelShow'.
+Param: message_list_visibility: (Optional) This controls whether the label appears in the message list view. Must be one of 'show', 'hide', default is 'show'.
+
+#!/usr/bin/env python3 ${GPTSCRIPT_TOOL_DIR}/main.py create_label
+
+---
 Name: Draft Context
 Type: context
 
@@ -173,9 +208,24 @@ Do not assist the user with drafting an email to forward an email in any way.
 
 ## End of instructions for Updating, Deleting, or Sending a Draft Email
 
+
+---
+Name: Modify Email Labels Context
+Type: context
+
+#!sys.echo
+
+## Instructions for modifying labels of an email
+
+If the user asks to move an email to a custom label, you should add the specified label and archive the email by removing it from the inbox.
+
+## End of instructions for modifying labels of an email
+
+
 ---
 Name: Email List Context
 Type: context
+Share Context: ../../time
 
 #!sys.echo
 

--- a/google/gmail/tool.gpt
+++ b/google/gmail/tool.gpt
@@ -17,7 +17,7 @@ Description: List emails in the user's Gmail account. By default, this will list
 Credential: ../credential
 Share Contexts: Email List Context
 Tools: github.com/gptscript-ai/datasets/filter
-Param: labels: (Optional: Default is 'inbox') The labels to list emails from, must be a comma separated list of labels. Valid built-in labels are 'inbox', 'starred', 'important', 'sent', 'drafts', 'trash', 'spam', 'all', as well as any custom labels the user has created. 
+Param: label_ids: (Optional: Default is 'inbox') The label_ids to list emails from, must be a comma separated list of label_ids. Valid built-in labels are 'inbox', 'starred', 'important', 'sent', 'drafts', 'trash', 'spam', 'all', as well as any custom label_ids the user has created. 
 Param: category: (Optional: Default is 'primary') The category of emails to list, only valid when `inbox` is in the labels list. Valid options are 'primary', 'social', 'promotions', 'updates', 'forums'. 
 Param: after: (Optional) Return only emails received strictly **after** this timestamp. Format: `YYYY-MM-DDTHH:MM:SS±HH:MM` (ISO 8601 format with timezone offset). 
 Param: before: (Optional) Return only emails received strictly **before** this timestamp. Format: `YYYY-MM-DDTHH:MM:SS±HH:MM` (ISO 8601 format with timezone offset). Time and timezone are required. (Optional)
@@ -70,8 +70,8 @@ Param: archive: (Optional) Set to true to archive the email (remove it from Inbo
 Param: mark_as_read: (Optional) Set to true to mark the email as read, or false to mark it as unread. Default is None (no change).
 Param: mark_as_starred: (Optional) Set to true to star the email, or false to remove the star. Default is None (no change).
 Param: mark_as_important: (Optional) Set to true to mark the email as important, or false to remove the important label. Default is None (no change).
-Param: add_labels: (Optional) A comma-separated list of custom label names to add to the email. Default is an empty list.
-Param: remove_labels: (Optional) A comma-separated list of custom label names to remove from the email. Default is an empty list.
+Param: add_label_ids: (Optional) A comma-separated list of custom label_ids to add to the email. Default is an empty list.
+Param: remove_label_ids: (Optional) A comma-separated list of custom label_ids to remove from the email. Default is an empty list.
 
 #!/usr/bin/env python3 ${GPTSCRIPT_TOOL_DIR}/main.py modify_message_labels
 
@@ -182,13 +182,32 @@ Param: label_id: (Optional) The ID of the label to return. Default to empty stri
 
 ---
 Name: Create Label
-Description: Create a custom label in a user's Gmail account.
+Description: Create a custom label in the user's Gmail account.
 Credential: ../credential
 Param: label_name: The name of the label to create.
 Param: label_list_visibility: (Optional) This controls whether and how the label appears in the Gmail sidebar (left panel). Must be one of 'labelShow', 'labelHide', 'labelShowIfUnread', default is 'labelShow'.
 Param: message_list_visibility: (Optional) This controls whether the label appears in the message list view. Must be one of 'show', 'hide', default is 'show'.
 
 #!/usr/bin/env python3 ${GPTSCRIPT_TOOL_DIR}/main.py create_label
+
+---
+Name: Update Label
+Description: Update a custom label in the user's Gmail account. Only fields that are provided will be updated.
+Credential: ../credential
+Param: label_id: The ID of the label to update.
+Param: label_name: (Optional) The new name of the label. 
+Param: label_list_visibility: (Optional) This controls whether and how the label appears in the Gmail sidebar (left panel). Must be one of 'labelShow', 'labelHide', 'labelShowIfUnread'.
+Param: message_list_visibility: (Optional) This controls whether the label appears in the message list view. Must be one of 'show', 'hide'.
+
+#!/usr/bin/env python3 ${GPTSCRIPT_TOOL_DIR}/main.py update_label
+
+---
+Name: Delete Label
+Description: Delete a custom label in the user's Gmail account.
+Credential: ../credential
+Param: label_id: The ID of the label to delete.
+
+#!/usr/bin/env python3 ${GPTSCRIPT_TOOL_DIR}/main.py delete_label
 
 ---
 Name: Draft Context


### PR DESCRIPTION
This PR:
- adds CRUD custom label tools to gmail bundle https://github.com/obot-platform/obot/issues/2590. Note: the list_labels tool will only display custom labels, and hide system/internal gmail labels.
- A new tool `Modify Email Labels` to support applying labels to gmail email: https://github.com/obot-platform/obot/issues/2591
  - mark email as read/unread
  - archive email
  - mark/remove email as starred
  - mark/remove email as important
  - apply/remove custom labels to email
- User can move email to a label(archive email automatically ) or apply label to email
- Show read/unread status, show categories(only if email in INBOX) in metadata when listing emails.
- Rename `List Inbox` to `List Emails`.