### PR TITLE
Enhance: Download URLs for workpsace files

### DIFF
--- a/workspace-files/main.go
+++ b/workspace-files/main.go
@@ -21,18 +21,18 @@ var (
 	FileEnv     = os.Getenv("FILENAME")
 	DirEnv      = os.Getenv("DIR")
 	MaxFileSize = 250_000
+	ThreadID    = os.Getenv("OBOT_THREAD_ID")
+	ServerURL   = os.Getenv("OBOT_SERVER_URL")
 )
 
-var unsupportedWriteFileTypes = []string{
-	".pdf", ".docx", ".doc", ".pptx", ".ppt", ".xlsx", ".xls", ".jpg", ".png", ".gif", ".mp3", ".mp4", ".zip", ".rar"}
+var unsupportedWriteFileTypes = []string{".pdf", ".docx", ".doc", ".pptx", ".ppt", ".xlsx", ".xls", ".jpg", ".png", ".gif", ".mp3", ".mp4", ".zip", ".rar"}
 var nonPlainTextFileTypes = []string{".pdf", ".pptx", ".ppt", ".docx", ".doc", ".odt", ".rtf", ".ipynb"} // ipynb is in json. we want to convert it to markdown
-
 
 func main() {
 	if len(os.Args) == 1 {
 		fmt.Printf(`
-Subcommands: read, write, copy
-env: FILENAME, CONTENT,  TO_FILENAME, GPTSCRIPT_WORKSPACE_DIR
+Subcommands: read, write, copy, download-url
+env: FILENAME, CONTENT, TO_FILENAME, GPTSCRIPT_WORKSPACE_DIR, OBOT_THREAD_ID, OBOT_SERVER_URL
 Usage: go run main.go <path>\n`)
 		return
 	}
@@ -70,6 +70,11 @@ Usage: go run main.go <path>\n`)
 		toFilename := gptscript.GetEnv("TO_FILENAME", "")
 		if err := copy(ctx, FileEnv, toFilename); err != nil {
 			fmt.Printf("Failed to copy %s to %s: %v\n", FileEnv, toFilename, err)
+			return
+		}
+	case "download-url":
+		if err := downloadURL(ctx, FileEnv); err != nil {
+			fmt.Printf("Failed to generate download URL for %s: %v\n", FileEnv, err)
 			return
 		}
 	}
@@ -173,7 +178,6 @@ func list(ctx context.Context, filename string) error {
 	return nil
 }
 
-
 func readNonPlainOrLargeFile(ctx context.Context, filename string) (string, error) {
 	// forward to a tool to handle non-plain text files or large files
 	client, err := gptscript.NewGPTScript()
@@ -190,7 +194,7 @@ func readNonPlainOrLargeFile(ctx context.Context, filename string) (string, erro
 	}
 
 	run, err := client.Run(ctx, "github.com/obot-platform/tools/file-summarizer/tool.gpt", gptscript.Options{
-		Input: string(jsonData),
+		Input:     string(jsonData),
 		Workspace: workspaceID,
 	})
 
@@ -278,4 +282,25 @@ func copy(ctx context.Context, filename, toFilename string) error {
 	}
 
 	return client.WriteFileInWorkspace(ctx, path.Join(FilesDir, toFilename), data)
+}
+
+func downloadURL(ctx context.Context, filename string) error {
+	if ThreadID == "" || ServerURL == "" {
+		return fmt.Errorf("OBOT_THREAD_ID and OBOT_SERVER_URL environment variables are required")
+	}
+
+	client, err := gptscript.NewGPTScript()
+	if err != nil {
+		return err
+	}
+
+	// Check if file exists
+	_, err = client.StatFileInWorkspace(ctx, path.Join(FilesDir, filename))
+	if err != nil {
+		return err
+	}
+
+	downloadURL := fmt.Sprintf("%s/api/threads/%s/file/%s", ServerURL, ThreadID, filename)
+	fmt.Println(downloadURL)
+	return nil
 }

--- a/workspace-files/tool.gpt
+++ b/workspace-files/tool.gpt
@@ -3,7 +3,7 @@ Description: Adds the capability for users to read and write workspace files
 Type: context
 Metadata: category: Capability
 Context: workspace_list
-Share Tools: workspace_read, workspace_write, workspace_copy
+Share Tools: workspace_read, workspace_write, workspace_copy, workspace_file_download_url
 Share Input Filter: input_parse
 
 #!/bin/bash
@@ -43,6 +43,13 @@ Credential: sys.model.provider.credential
 Params: filename: The filename to read
 
 #!${GPTSCRIPT_TOOL_DIR}/bin/gptscript-go-tool read
+
+---
+Name: workspace_file_download_url
+Description: Get a URL that the current user can use to download a given workspace file. This URL is authenticated and authorized to the curernt user and is not appropriate for public sharing.
+Params: filename: The filename to get a download URL for
+
+#!${GPTSCRIPT_TOOL_DIR}/bin/gptscript-go-tool download-url
 
 ---
 Name: workspace_write

--- a/workspace-files/tool.gpt
+++ b/workspace-files/tool.gpt
@@ -46,7 +46,7 @@ Params: filename: The filename to read
 
 ---
 Name: workspace_file_download_url
-Description: Get a URL that the current user can use to download a given workspace file. This URL is authenticated and authorized to the curernt user and is not appropriate for public sharing.
+Description: Get a URL that the current user can use to download a given workspace file. This URL is authenticated and authorized to the current user and is not appropriate for public sharing.
 Params: filename: The filename to get a download URL for
 
 #!${GPTSCRIPT_TOOL_DIR}/bin/gptscript-go-tool download-url


### PR DESCRIPTION
Add a tool that lets the LLM get the download URL for a workspace file

Signed-off-by: Craig Jellick <craig@acorn.io>
