### PR TITLE
enhance: add token usage to Anthropic model provider

### DIFF
--- a/anthropic-model-provider-go/main.go
+++ b/anthropic-model-provider-go/main.go
@@ -14,10 +14,9 @@ func main() {
 	isValidate := len(os.Args) > 1 && os.Args[1] == "validate"
 
 	cfg := &proxy.Config{
-		APIKey:          os.Getenv("OBOT_ANTHROPIC_MODEL_PROVIDER_API_KEY"), // optional, as e.g. Ollama doesn't require an API key
-		ListenPort:      os.Getenv("PORT"),
-		BaseURL:         "https://api.anthropic.com/v1/",
-		RewriteModelsFn: aproxy.RewriteModelsResponse,
+		APIKey:     os.Getenv("OBOT_ANTHROPIC_MODEL_PROVIDER_API_KEY"), // optional, as e.g. Ollama doesn't require an API key
+		ListenPort: os.Getenv("PORT"),
+		BaseURL:    "https://api.anthropic.com/v1/",
 		RewriteHeaderFn: func(header http.Header) {
 			header.Del("Authorization")
 			header.Set("x-api-key", os.Getenv("OBOT_ANTHROPIC_MODEL_PROVIDER_API_KEY"))

--- a/tests/tool_test.go
+++ b/tests/tool_test.go
@@ -29,7 +29,7 @@ func TestGPTScriptLoadTools(t *testing.T) {
 
 	// Add assertions and test cases here
 	if client == nil {
-		t.Error("Expected non-nil client")
+		t.Fatal("Expected non-nil client")
 	}
 
 	idx, err := readRegistry(ctx, registryURL, client)


### PR DESCRIPTION
This change also removes the old python-based Anthropic model provider because it isn't being used anymore. Lastly, some simplifications to the OpenAI proxy are made.