### PR TITLE
chore: improve outlook mail tool names and descriptions

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -62,7 +62,7 @@ tools:
   shell:
     reference: ./shell
   word:
-    reference: ./word
+    reference: ./microsoft365/word
   tavily:
     reference: ./search/tavily
   googlecustomsearch:

--- a/microsoft365/outlook/mail/main.go
+++ b/microsoft365/outlook/mail/main.go
@@ -31,15 +31,15 @@ func main() {
 			fmt.Printf("failed to list mail folders: %v\n", err)
 			os.Exit(1)
 		}
-	case "listMessages":
-		if err := commands.ListMessages(
+	case "listEmails":
+		if err := commands.ListEmails(
 			context.Background(),
 			os.Getenv("FOLDER_ID"),
 			os.Getenv("START"),
 			os.Getenv("END"),
 			os.Getenv("LIMIT"),
 		); err != nil {
-			fmt.Printf("failed to list mail: %v\n", err)
+			fmt.Printf("failed to list emails: %v\n", err)
 			os.Exit(1)
 		}
 	case "listGroupThreads":
@@ -58,13 +58,13 @@ func main() {
 			fmt.Printf("failed to list groups: %v\n", err)
 			os.Exit(1)
 		}
-	case "getMessageDetails":
-		if err := commands.GetMessageDetails(context.Background(), os.Getenv("MESSAGE_ID")); err != nil {
-			fmt.Printf("failed to get message details: %v\n", err)
+	case "getEmailDetails":
+		if err := commands.GetEmailDetails(context.Background(), os.Getenv("EMAIL_ID")); err != nil {
+			fmt.Printf("failed to get email details: %v\n", err)
 			os.Exit(1)
 		}
-	case "searchMessages":
-		if err := commands.SearchMessages(
+	case "searchEmails":
+		if err := commands.SearchEmails(
 			context.Background(),
 			os.Getenv("SUBJECT"),
 			os.Getenv("FROM_ADDRESS"),
@@ -74,7 +74,7 @@ func main() {
 			os.Getenv("END"),
 			os.Getenv("LIMIT"),
 		); err != nil {
-			fmt.Printf("failed to search messages: %v\n", err)
+			fmt.Printf("failed to search emails: %v\n", err)
 			os.Exit(1)
 		}
 	case "createDraft":
@@ -82,9 +82,9 @@ func main() {
 			fmt.Printf("failed to create draft: %v\n", err)
 			os.Exit(1)
 		}
-	case "createGroupThreadMessage":
-		if err := commands.CreateGroupThreadMessage(context.Background(), os.Getenv("GROUP_ID"), os.Getenv("REPLY_TO_THREAD_ID"), getDraftInfoFromEnv()); err != nil {
-			fmt.Printf("failed to create group thread message: %v\n", err)
+	case "createGroupThreadEmail":
+		if err := commands.CreateGroupThreadEmail(context.Background(), os.Getenv("GROUP_ID"), os.Getenv("REPLY_TO_THREAD_ID"), getDraftInfoFromEnv()); err != nil {
+			fmt.Printf("failed to create group thread email: %v\n", err)
 			os.Exit(1)
 		}
 	case "sendDraft":
@@ -92,9 +92,9 @@ func main() {
 			fmt.Printf("failed to send draft: %v\n", err)
 			os.Exit(1)
 		}
-	case "deleteMessage":
-		if err := commands.DeleteMessage(context.Background(), os.Getenv("MESSAGE_ID")); err != nil {
-			fmt.Printf("failed to delete message: %v\n", err)
+	case "deleteEmail":
+		if err := commands.DeleteEmail(context.Background(), os.Getenv("EMAIL_ID")); err != nil {
+			fmt.Printf("failed to delete email: %v\n", err)
 			os.Exit(1)
 		}
 	case "deleteGroupThread":
@@ -102,9 +102,9 @@ func main() {
 			fmt.Printf("failed to delete group thread: %v\n", err)
 			os.Exit(1)
 		}
-	case "moveMessage":
-		if err := commands.MoveMessage(context.Background(), os.Getenv("MESSAGE_ID"), os.Getenv("DESTINATION_FOLDER_ID")); err != nil {
-			fmt.Printf("failed to move message: %v\n", err)
+	case "moveEmail":
+		if err := commands.MoveEmail(context.Background(), os.Getenv("EMAIL_ID"), os.Getenv("DESTINATION_FOLDER_ID")); err != nil {
+			fmt.Printf("failed to move email: %v\n", err)
 			os.Exit(1)
 		}
 	case "getMyEmailAddress":
@@ -113,7 +113,7 @@ func main() {
 			os.Exit(1)
 		}
 	case "listAttachments":
-		if err := commands.ListAttachments(context.Background(), os.Getenv("MESSAGE_ID")); err != nil {
+		if err := commands.ListAttachments(context.Background(), os.Getenv("EMAIL_ID")); err != nil {
 			fmt.Printf("failed to list attachments: %v\n", err)
 			os.Exit(1)
 		}
@@ -121,41 +121,40 @@ func main() {
 		client := apiclient.NewClientFromEnv()
 
 		if err := commands.DownloadAttachment(context.Background(), os.Getenv("ATTACHMENT_ID"), client, &commands.DownloadAttachmentOpts{
-			MessageID:     os.Getenv("MESSAGE_ID"),
+			EmailID:       os.Getenv("EMAIL_ID"),
 			ThreadID:      threadID,
 			ProjectID:     projectID,
 			AssistantID:   assistantID,
 			GroupID:       os.Getenv("GROUP_ID"),
 			GroupThreadID: os.Getenv("THREAD_ID"),
-			PostID:        os.Getenv("POST_ID"),
 		}); err != nil {
 			fmt.Printf("failed to download attachment: %v\n", err)
 			os.Exit(1)
 		}
-	case "getAttachment":
-		if err := commands.GetAttachment(context.Background(), os.Getenv("MESSAGE_ID"), os.Getenv("ATTACHMENT_ID")); err != nil {
-			fmt.Printf("failed to get attachment: %v\n", err)
+	case "readAttachment":
+		if err := commands.ReadAttachment(context.Background(), os.Getenv("EMAIL_ID"), os.Getenv("ATTACHMENT_ID")); err != nil {
+			fmt.Printf("failed to read attachment: %v\n", err)
 			os.Exit(1)
 		}
-	case "listGroupThreadMessageAttachments":
-		if err := commands.ListGroupThreadMessageAttachments(
+	case "listGroupThreadEmailAttachments":
+		if err := commands.ListGroupThreadEmailAttachments(
 			context.Background(),
 			os.Getenv("GROUP_ID"),
 			os.Getenv("THREAD_ID"),
-			os.Getenv("POST_ID"),
+			os.Getenv("EMAIL_ID"),
 		); err != nil {
-			fmt.Printf("failed to list group thread message attachments: %v\n", err)
+			fmt.Printf("failed to list group thread email attachments: %v\n", err)
 			os.Exit(1)
 		}
-	case "getGroupThreadMessageAttachment":
-		if err := commands.GetGroupThreadMessageAttachment(
+	case "getGroupThreadEmailAttachment":
+		if err := commands.GetGroupThreadEmailAttachment(
 			context.Background(),
 			os.Getenv("GROUP_ID"),
 			os.Getenv("THREAD_ID"),
-			os.Getenv("POST_ID"),
+			os.Getenv("EMAIL_ID"),
 			os.Getenv("ATTACHMENT_ID"),
 		); err != nil {
-			fmt.Printf("failed to get group thread message attachment: %v\n", err)
+			fmt.Printf("failed to get group thread email attachment: %v\n", err)
 			os.Exit(1)
 		}
 	default:
@@ -178,14 +177,14 @@ func getDraftInfoFromEnv() graph.DraftInfo {
 	}
 
 	info := graph.DraftInfo{
-		Subject:          os.Getenv("SUBJECT"),
-		Body:             os.Getenv("BODY"),
-		Recipients:       smartSplit(os.Getenv("RECIPIENTS"), ","),
-		CC:               smartSplit(os.Getenv("CC"), ","),
-		BCC:              smartSplit(os.Getenv("BCC"), ","),
-		Attachments:      attachments,
-		ReplyAll:         os.Getenv("REPLY_ALL") == "true",
-		ReplyToMessageID: os.Getenv("REPLY_MESSAGE_ID"),
+		Subject:        os.Getenv("SUBJECT"),
+		Body:           os.Getenv("BODY"),
+		Recipients:     smartSplit(os.Getenv("RECIPIENTS"), ","),
+		CC:             smartSplit(os.Getenv("CC"), ","),
+		BCC:            smartSplit(os.Getenv("BCC"), ","),
+		Attachments:    attachments,
+		ReplyAll:       os.Getenv("REPLY_ALL") == "true",
+		ReplyToEmailID: os.Getenv("REPLY_EMAIL_ID"),
 	}
 
 	// We need to unset BODY, because if it's still set when we try to write files to the workspace,

--- a/microsoft365/outlook/mail/pkg/commands/createDraft.go
+++ b/microsoft365/outlook/mail/pkg/commands/createDraft.go
@@ -19,7 +19,7 @@ func CreateDraft(ctx context.Context, info graph.DraftInfo) error {
 	}
 
 	var draft models.Messageable
-	if info.ReplyToMessageID != "" {
+	if info.ReplyToEmailID != "" {
 		draft, err = graph.CreateDraftReply(ctx, c, info)
 		if err != nil {
 			return fmt.Errorf("failed to create draft reply: %w", err)

--- a/microsoft365/outlook/mail/pkg/commands/createGroupThreadEmail.go
+++ b/microsoft365/outlook/mail/pkg/commands/createGroupThreadEmail.go
@@ -10,7 +10,7 @@ import (
 	"github.com/obot-platform/tools/microsoft365/outlook/mail/pkg/util"
 )
 
-func CreateGroupThreadMessage(ctx context.Context, groupID, replyToThreadID string, info graph.DraftInfo) error {
+func CreateGroupThreadEmail(ctx context.Context, groupID, replyToThreadID string, info graph.DraftInfo) error {
 	c, err := client.NewClient(global.AllScopes)
 	if err != nil {
 		return fmt.Errorf("failed to create client: %w", err)
@@ -19,17 +19,17 @@ func CreateGroupThreadMessage(ctx context.Context, groupID, replyToThreadID stri
 	if replyToThreadID != "" { // reply to a thread
 		err = graph.ReplyToGroupThreadMessage(ctx, c, groupID, replyToThreadID, info)
 		if err != nil {
-			return fmt.Errorf("failed to reply to group thread message: %w", err)
+			return fmt.Errorf("failed to reply to group thread email: %w", err)
 		}
-		fmt.Println("Group thread message replied to successfully")
+		fmt.Println("Group thread email replied to successfully")
 		return nil
 	} else { // create a new thread
 		threads, err := graph.CreateGroupThreadMessage(ctx, c, groupID, info)
 		if err != nil {
-			return fmt.Errorf("failed to create group thread message: %w", err)
+			return fmt.Errorf("failed to create group thread email: %w", err)
 		}
 
-		fmt.Println("Group thread message created successfully, thread ID:", util.Deref(threads.GetId()))
+		fmt.Println("Group thread email created successfully, thread ID:", util.Deref(threads.GetId()))
 		return nil
 	}
 }

--- a/microsoft365/outlook/mail/pkg/commands/deleteEmail.go
+++ b/microsoft365/outlook/mail/pkg/commands/deleteEmail.go
@@ -10,10 +10,10 @@ import (
 	"github.com/obot-platform/tools/microsoft365/outlook/mail/pkg/graph"
 )
 
-func DeleteMessage(ctx context.Context, messageID string) error {
-	trueMessageID, err := id.GetOutlookID(ctx, messageID)
+func DeleteEmail(ctx context.Context, emailID string) error {
+	trueEmailID, err := id.GetOutlookID(ctx, emailID)
 	if err != nil {
-		return fmt.Errorf("failed to get message ID: %w", err)
+		return fmt.Errorf("failed to get outlook ID: %w", err)
 	}
 
 	c, err := client.NewClient(global.AllScopes)
@@ -21,10 +21,10 @@ func DeleteMessage(ctx context.Context, messageID string) error {
 		return fmt.Errorf("failed to create client: %w", err)
 	}
 
-	if err := graph.DeleteMessage(ctx, c, trueMessageID); err != nil {
-		return fmt.Errorf("failed to delete message: %w", err)
+	if err := graph.DeleteMessage(ctx, c, trueEmailID); err != nil {
+		return fmt.Errorf("failed to delete email: %w", err)
 	}
 
-	fmt.Println("Message deleted successfully")
+	fmt.Println("Email deleted successfully.")
 	return nil
 }

--- a/microsoft365/outlook/mail/pkg/commands/downloadAttachment.go
+++ b/microsoft365/outlook/mail/pkg/commands/downloadAttachment.go
@@ -14,12 +14,8 @@ import (
 )
 
 type DownloadAttachmentOpts struct {
-	// Message fields
-	MessageID string
-
-	// Group message fields
+	EmailID       string
 	GroupID       string
-	PostID        string
 	GroupThreadID string
 
 	// Obot client parameters
@@ -35,28 +31,28 @@ func DownloadAttachment(ctx context.Context, attachmentID string, obotClient *ap
 	}
 
 	var requestInfo *abstractions.RequestInformation
-	if opts.GroupID != "" && opts.GroupThreadID != "" && opts.PostID != "" {
-		// Group thread post attachment
+	if opts.GroupID != "" && opts.GroupThreadID != "" {
+		// Group thread email attachment
 		requestInfo, err = c.Groups().
 			ByGroupId(opts.GroupID).
 			Threads().
 			ByConversationThreadId(opts.GroupThreadID).
 			Posts().
-			ByPostId(opts.PostID).
+			ByPostId(opts.EmailID).
 			Attachments().
 			ByAttachmentId(attachmentID).
 			ToGetRequestInformation(ctx, nil)
 	} else {
-		// Regular message attachment
-		var trueMessageID string
-		trueMessageID, err = id.GetOutlookID(ctx, opts.MessageID)
+		// Regular email attachment
+		var trueEmailID string
+		trueEmailID, err = id.GetOutlookID(ctx, opts.EmailID)
 		if err != nil {
 			return fmt.Errorf("failed to get outlook ID: %w", err)
 		}
 
 		requestInfo, err = c.Me().
 			Messages().
-			ByMessageId(trueMessageID).
+			ByMessageId(trueEmailID).
 			Attachments().
 			ByAttachmentId(attachmentID).
 			ToGetRequestInformation(ctx, nil)

--- a/microsoft365/outlook/mail/pkg/commands/getEmailDetails.go
+++ b/microsoft365/outlook/mail/pkg/commands/getEmailDetails.go
@@ -12,8 +12,8 @@ import (
 	"github.com/obot-platform/tools/microsoft365/outlook/mail/pkg/util"
 )
 
-func GetMessageDetails(ctx context.Context, messageID string) error {
-	trueMessageID, err := id.GetOutlookID(ctx, messageID)
+func GetEmailDetails(ctx context.Context, emailID string) error {
+	trueEmailID, err := id.GetOutlookID(ctx, emailID)
 	if err != nil {
 		return fmt.Errorf("failed to get outlook ID: %w", err)
 	}
@@ -23,12 +23,12 @@ func GetMessageDetails(ctx context.Context, messageID string) error {
 		return fmt.Errorf("failed to create client: %w", err)
 	}
 
-	result, err := graph.GetMessageDetails(ctx, c, trueMessageID)
+	result, err := graph.GetMessageDetails(ctx, c, trueEmailID)
 	if err != nil {
-		return fmt.Errorf("failed to get message details: %w", err)
+		return fmt.Errorf("failed to get email details: %w", err)
 	}
 
-	result.SetId(&trueMessageID)
+	result.SetId(&trueEmailID)
 
 	parentFolderID, err := id.GetOutlookID(ctx, util.Deref(result.GetParentFolderId()))
 	if err != nil {

--- a/microsoft365/outlook/mail/pkg/commands/getGroupThreadEmailAttachment.go
+++ b/microsoft365/outlook/mail/pkg/commands/getGroupThreadEmailAttachment.go
@@ -9,15 +9,15 @@ import (
 	"github.com/obot-platform/tools/microsoft365/outlook/mail/pkg/graph"
 )
 
-func GetGroupThreadMessageAttachment(ctx context.Context, groupID, threadID, postID, attachmentID string) error {
-	c, err := client.NewClient(global.AllScopes)
+func GetGroupThreadEmailAttachment(ctx context.Context, groupID, threadID, emailID, attachmentID string) error {
+	c, err := client.NewClient(global.ReadOnlyScopes)
 	if err != nil {
 		return fmt.Errorf("failed to create client: %w", err)
 	}
 
-	result, err := graph.GetGroupThreadMessageAttachment(ctx, c, groupID, threadID, postID, attachmentID)
+	result, err := graph.GetGroupThreadMessageAttachment(ctx, c, groupID, threadID, emailID, attachmentID)
 	if err != nil {
-		return fmt.Errorf("failed to get attachment: %w", err)
+		return fmt.Errorf("failed to get group thread email attachment: %w", err)
 	}
 
 	fmt.Println(result)

--- a/microsoft365/outlook/mail/pkg/commands/listAttachments.go
+++ b/microsoft365/outlook/mail/pkg/commands/listAttachments.go
@@ -10,8 +10,8 @@ import (
 	"github.com/obot-platform/tools/microsoft365/outlook/mail/pkg/graph"
 )
 
-func ListAttachments(ctx context.Context, messageID string) error {
-	trueMessageID, err := id.GetOutlookID(ctx, messageID)
+func ListAttachments(ctx context.Context, emailID string) error {
+	trueEmailID, err := id.GetOutlookID(ctx, emailID)
 	if err != nil {
 		return fmt.Errorf("failed to get outlook ID: %w", err)
 	}
@@ -21,7 +21,7 @@ func ListAttachments(ctx context.Context, messageID string) error {
 		return fmt.Errorf("failed to create client: %w", err)
 	}
 
-	attachments, err := graph.ListAttachments(ctx, c, trueMessageID)
+	attachments, err := graph.ListAttachments(ctx, c, trueEmailID)
 	if err != nil {
 		return fmt.Errorf("failed to list attachments: %w", err)
 	}

--- a/microsoft365/outlook/mail/pkg/commands/listEmails.go
+++ b/microsoft365/outlook/mail/pkg/commands/listEmails.go
@@ -15,15 +15,15 @@ import (
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
 )
 
-func ListMessages(ctx context.Context, folderID, start, end, limit string) error {
+func ListEmails(ctx context.Context, folderID, start, end, limitStr string) error {
 	var (
 		// TODO: Change the default to a value < 1 when we have pagination implemented to trigger
 		// listing all messages.
 		limitInt int = 100
 		err      error
 	)
-	if limit != "" {
-		limitInt, err = strconv.Atoi(limit)
+	if limitStr != "" {
+		limitInt, err = strconv.Atoi(limitStr)
 		if err != nil {
 			return fmt.Errorf("failed to parse limit: %w", err)
 		}

--- a/microsoft365/outlook/mail/pkg/commands/listGroupThreadEmailAttachments.go
+++ b/microsoft365/outlook/mail/pkg/commands/listGroupThreadEmailAttachments.go
@@ -9,15 +9,15 @@ import (
 	"github.com/obot-platform/tools/microsoft365/outlook/mail/pkg/graph"
 )
 
-func ListGroupThreadMessageAttachments(ctx context.Context, groupID, threadID, postID string) error {
-	c, err := client.NewClient(global.AllScopes)
+func ListGroupThreadEmailAttachments(ctx context.Context, groupID, threadID, emailID string) error {
+	c, err := client.NewClient(global.ReadOnlyScopes)
 	if err != nil {
 		return fmt.Errorf("failed to create client: %w", err)
 	}
 
-	attachments, err := graph.ListGroupThreadMessageAttachments(ctx, c, groupID, threadID, postID)
+	attachments, err := graph.ListGroupThreadMessageAttachments(ctx, c, groupID, threadID, emailID)
 	if err != nil {
-		return fmt.Errorf("failed to list attachments: %w", err)
+		return fmt.Errorf("failed to list group thread email attachments: %w", err)
 	}
 
 	for _, attachment := range attachments {

--- a/microsoft365/outlook/mail/pkg/commands/moveEmail.go
+++ b/microsoft365/outlook/mail/pkg/commands/moveEmail.go
@@ -11,10 +11,10 @@ import (
 	"github.com/obot-platform/tools/microsoft365/outlook/mail/pkg/util"
 )
 
-func MoveMessage(ctx context.Context, messageID, destinationFolderID string) error {
-	trueMessageID, err := id.GetOutlookID(ctx, messageID)
+func MoveEmail(ctx context.Context, emailID, destinationFolderID string) error {
+	trueEmailID, err := id.GetOutlookID(ctx, emailID)
 	if err != nil {
-		return fmt.Errorf("failed to get message ID: %w", err)
+		return fmt.Errorf("failed to get outlook ID: %w", err)
 	}
 
 	trueDestinationFolderID, err := id.GetOutlookID(ctx, destinationFolderID)
@@ -27,17 +27,16 @@ func MoveMessage(ctx context.Context, messageID, destinationFolderID string) err
 		return fmt.Errorf("failed to create client: %w", err)
 	}
 
-	message, err := graph.MoveMessage(ctx, c, trueMessageID, trueDestinationFolderID)
+	email, err := graph.MoveMessage(ctx, c, trueEmailID, trueDestinationFolderID)
 	if err != nil {
-		return fmt.Errorf("failed to move message: %w", err)
+		return fmt.Errorf("failed to move email: %w", err)
 	}
 
-	// Save the new message ID
-	newMessageID, err := id.SetOutlookID(ctx, util.Deref(message.GetId()))
+	newEmailID, err := id.SetOutlookID(ctx, util.Deref(email.GetId()))
 	if err != nil {
-		return fmt.Errorf("failed to save new message ID: %w", err)
+		return fmt.Errorf("failed to set outlook ID: %w", err)
 	}
 
-	fmt.Printf("Message moved successfully. New message ID: %s\n", newMessageID)
+	fmt.Printf("Email moved successfully. New email ID: %s\n", newEmailID)
 	return nil
 }

--- a/microsoft365/outlook/mail/pkg/commands/readAttachment.go
+++ b/microsoft365/outlook/mail/pkg/commands/readAttachment.go
@@ -10,8 +10,8 @@ import (
 	"github.com/obot-platform/tools/microsoft365/outlook/mail/pkg/graph"
 )
 
-func GetAttachment(ctx context.Context, messageID, attachmentID string) error {
-	trueMessageID, err := id.GetOutlookID(ctx, messageID)
+func ReadAttachment(ctx context.Context, emailID, attachmentID string) error {
+	trueEmailID, err := id.GetOutlookID(ctx, emailID)
 	if err != nil {
 		return fmt.Errorf("failed to get outlook ID: %w", err)
 	}
@@ -22,7 +22,7 @@ func GetAttachment(ctx context.Context, messageID, attachmentID string) error {
 	}
 
 	// Get attachment as a Parsable object
-	requestInfo, err := c.Me().Messages().ByMessageId(trueMessageID).Attachments().ByAttachmentId(attachmentID).ToGetRequestInformation(ctx, nil)
+	requestInfo, err := c.Me().Messages().ByMessageId(trueEmailID).Attachments().ByAttachmentId(attachmentID).ToGetRequestInformation(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("failed to create request info: %w", err)
 	}

--- a/microsoft365/outlook/mail/pkg/commands/searchEmails.go
+++ b/microsoft365/outlook/mail/pkg/commands/searchEmails.go
@@ -15,13 +15,13 @@ import (
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
 )
 
-func SearchMessages(ctx context.Context, subject, fromAddress, fromName, folderID, start, end, limit string) error {
+func SearchEmails(ctx context.Context, subject, fromAddress, fromName, folderID, start, end, limitStr string) error {
 	var (
 		limitInt = 10
 		err      error
 	)
-	if limit != "" {
-		limitInt, err = strconv.Atoi(limit)
+	if limitStr != "" {
+		limitInt, err = strconv.Atoi(limitStr)
 		if err != nil {
 			return fmt.Errorf("failed to parse limit: %w", err)
 		}

--- a/microsoft365/outlook/mail/pkg/graph/mail.go
+++ b/microsoft365/outlook/mail/pkg/graph/mail.go
@@ -147,7 +147,7 @@ type DraftInfo struct {
 	Recipients, CC, BCC []string // slice of email addresses
 	Attachments         []string // slice of workspace file paths
 	ReplyAll            bool
-	ReplyToMessageID    string
+	ReplyToEmailID      string
 }
 
 var (
@@ -200,7 +200,7 @@ func CreateDraft(ctx context.Context, client *msgraphsdkgo.GraphServiceClient, i
 }
 
 func CreateDraftReply(ctx context.Context, client *msgraphsdkgo.GraphServiceClient, info DraftInfo) (models.Messageable, error) {
-	trueMessageID, err := id.GetOutlookID(ctx, info.ReplyToMessageID)
+	trueMessageID, err := id.GetOutlookID(ctx, info.ReplyToEmailID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get message ID: %w", err)
 	}

--- a/microsoft365/outlook/mail/tool.gpt
+++ b/microsoft365/outlook/mail/tool.gpt
@@ -2,11 +2,11 @@
 Name: Outlook Mail
 Description: Tools for interacting with Microsoft Outlook Mail.
 Metadata: bundle: true
-Share Tools: List Mail Folders, List Messages, Get Message Details, Search Messages, Create Draft, Create Group Thread Message, Send Draft, Delete Message, Move Message, List Groups, List Group Threads, Delete Group Thread, Current Email, List Attachments, Download Attachment, Read Attachment, List Group Thread Message Attachments, Get Group Thread Message Attachment, Download Group Thread Message Attachment
+Share Tools: List Mail Folders, List Emails, Get Email Details, Search Emails, Create Draft, Create Group Thread Email, Send Draft, Delete Email, Move Email, List Groups, List Group Threads, Delete Group Thread, Current Email, List Attachments, Download Attachment, Read Attachment, List Group Thread Email Attachments, Get Group Thread Email Attachment, Download Group Thread Email Attachment
 
 ---
 Name: List Mail Folders
-Description: Lists all available mail folders.
+Description: Lists all available Outlook mail folders.
 Share Context: Outlook Mail Context
 Share Context: Datasets Output Context from github.com/gptscript-ai/datasets/filter
 Tools: github.com/gptscript-ai/datasets/filter
@@ -15,83 +15,83 @@ Credential: ../../credential
 #!${GPTSCRIPT_TOOL_DIR}/bin/gptscript-go-tool listMailFolders
 
 ---
-Name: List Messages
-Description: Lists messages in a folder.
+Name: List Emails
+Description: Lists emails in an Outlook folder.
 Share Context: Outlook Mail Context
 Share Context: Datasets Output Context from github.com/gptscript-ai/datasets/filter
 Tools: github.com/gptscript-ai/datasets/filter
 Credential: ../../credential
 Share Tools: List Mail Folders
-Param: folder_id: (Optional) The ID of the folder to list messages in. If unset, lists messages from all folders.
-Param: start: (Optional) The RFC3339 formatted start date and time of the time frame to list messages within.
-Param: end: (Optional) The RFC3339 formatted end date and time of the time frame to list messages within.
-Param: limit: (Optional) The maximum number of messages to return. If unset, returns up to 100 messages.
+Param: folder_id: (Optional) The ID of the folder to list emails in. If unset, lists emails from all folders.
+Param: start: (Optional) The RFC3339 formatted start date and time of the time frame to list emails within.
+Param: end: (Optional) The RFC3339 formatted end date and time of the time frame to list emails within.
+Param: limit: (Optional) The maximum number of emails to return. If unset, returns up to 100 emails.
 
-#!${GPTSCRIPT_TOOL_DIR}/bin/gptscript-go-tool listMessages
+#!${GPTSCRIPT_TOOL_DIR}/bin/gptscript-go-tool listEmails
 
 ---
-Name: Get Message Details
-Description: Get the details of a message.
+Name: Get Email Details
+Description: Get the details of an Outlook email.
 Share Context: Outlook Mail Context
 Credential: ../../credential
-Share Tools: List Messages, Search Messages
-Param: message_id: The ID of the message to get details for.
+Share Tools: List Emails, Search Emails
+Param: email_id: The ID of the email to get details for.
 
-#!${GPTSCRIPT_TOOL_DIR}/bin/gptscript-go-tool getMessageDetails
+#!${GPTSCRIPT_TOOL_DIR}/bin/gptscript-go-tool getEmailDetails
 
 ---
-Name: Search Messages
-Description: Search for messages. At least one of subject, from_address, or from_name must be specified.
+Name: Search Emails
+Description: Search for emails in Outlook. At least one of subject, from_address, or from_name must be specified.
 Share Context: Outlook Mail Context
 Credential: ../../credential
 Share Context: Datasets Output Context from github.com/gptscript-ai/datasets/filter
 Tools: github.com/gptscript-ai/datasets/filter
 Share Tools: List Mail Folders
-Param: subject: (Optional) Search query for the subject of the message.
+Param: subject: (Optional) Search query for the subject of the email.
 Param: from_address: (Optional) Search query for the email address of the sender.
 Param: from_name: (Optional) Search query for the name of the sender.
 Param: folder_id: (Optional) The ID of the folder to search in. If unset, will search all folders.
 Param: start: (Optional) The start date and time of the time frame to search within, in RFC 3339 format.
 Param: end: (Optional) The end date and time of the time frame to search within, in RFC 3339 format.
-Param: limit: (Optional, default 10) The maximum number of messages to return.
+Param: limit: (Optional, default 10) The maximum number of emails to return.
 
-#!${GPTSCRIPT_TOOL_DIR}/bin/gptscript-go-tool searchMessages
+#!${GPTSCRIPT_TOOL_DIR}/bin/gptscript-go-tool searchEmails
 
 ---
 Name: Create Draft
-Description: Create (but do not send) a draft individual message.
+Description: Create (but do not send) a draft individual Outlook email.
 Share Context: Outlook Mail Context
 Credential: ../../credential
 Share Tools: Send Draft
-Param: subject: The subject of the message.
-Param: body: The body of the message in markdown format.
-Param: recipients: A comma-separated list of email addresses to send the message to. No spaces. Example: person1@example.com,person2@example.com
-Param: cc: (Optional) A comma-separated list of email addresses to CC on the message. No spaces. Example: person1@example.com,person2@example.com
-Param: bcc: (Optional) A comma-separated list of email addresses to BCC on the message. No spaces. Example: person1@example.com,person2@example.com
+Param: subject: The subject of the email.
+Param: body: The body of the email in markdown format.
+Param: recipients: A comma-separated list of email addresses to send the email to. No spaces. Example: person1@example.com,person2@example.com
+Param: cc: (Optional) A comma-separated list of email addresses to CC on the email. No spaces. Example: person1@example.com,person2@example.com
+Param: bcc: (Optional) A comma-separated list of email addresses to BCC on the email. No spaces. Example: person1@example.com,person2@example.com
 Param: attachments: (Optional) A comma separated list of workspace file paths to attach to the email.
-Param: reply_message_id: (Optional) The ID of the message to reply to.
-Param: reply_all: (Optional, default false) Whether to reply to all. If true, CC will be the original message's CC.
+Param: reply_email_id: (Optional) The ID of the email to reply to.
+Param: reply_all: (Optional, default false) Whether to reply to all. If true, CC will be the original email's CC.
 
 #!${GPTSCRIPT_TOOL_DIR}/bin/gptscript-go-tool createDraft
 
 ---
-Name: Create Group Thread Message
-Description: Compose a group thread message that is always sent to the microsoft365 group email address. Allow the user to add additional recipients who are not part of the group. Before sending, you MUST politely confirm the subject and body of the message with the user.
+Name: Create Group Thread Email
+Description: Compose a group thread email in Outlook that is always sent to the Microsoft 365 group email address. Allow the user to add additional recipients who are not part of the group. Before sending, you MUST politely confirm the subject and body of the email with the user.
 Share Context: Outlook Mail Context
 Credential: ../../credential
 Share Tools: Create Draft
-Param: group_id: (Required) The ID of the group to create the thread message in.
-Param: subject: (Required) The subject of the message.
-Param: body: (Required) The body of the message in markdown format.
+Param: group_id: (Required) The ID of the group to create the thread email in.
+Param: subject: (Required) The subject of the email.
+Param: body: (Required) The body of the email in markdown format.
 Param: reply_to_thread_id: (Optional) The ID of the thread to reply to. If unset, a new thread will be created.
-Param: recipients: (Optional) The additional recipients to send the message to, must be a comma-separated list of email addresses. 
+Param: recipients: (Optional) The additional recipients to send the email to, must be a comma-separated list of email addresses.
 Param: attachments: (Optional) A comma separated list of workspace file paths to attach to the email.
 
-#!${GPTSCRIPT_TOOL_DIR}/bin/gptscript-go-tool createGroupThreadMessage
+#!${GPTSCRIPT_TOOL_DIR}/bin/gptscript-go-tool createGroupThreadEmail
 
 ---
 Name: Send Draft
-Description: Send an existing draft message.
+Description: Send an existing draft email in Outlook.
 Share Context: Outlook Mail Context
 Credential: ../../credential
 Share Tools: Create Draft
@@ -100,29 +100,29 @@ Param: draft_id: The ID of the draft to send.
 #!${GPTSCRIPT_TOOL_DIR}/bin/gptscript-go-tool sendDraft
 
 ---
-Name: Delete Message
-Description: Delete a message.
+Name: Delete Email
+Description: Delete an Outlook email.
 Share Context: Outlook Mail Context
 Credential: ../../credential
-Share Tools: List Messages, Search Messages
-Param: message_id: The ID of the message to delete. This is NOT a mail folder ID.
+Share Tools: List Emails, Search Emails
+Param: email_id: The ID of the email to delete. This is NOT a mail folder ID.
 
-#!${GPTSCRIPT_TOOL_DIR}/bin/gptscript-go-tool deleteMessage
+#!${GPTSCRIPT_TOOL_DIR}/bin/gptscript-go-tool deleteEmail
 
 ---
-Name: Move Message
-Description: Moves a message to a folder.
+Name: Move Email
+Description: Moves an email to a different Outlook folder.
 Share Context: Outlook Mail Context
 Credential: ../../credential
-Share Tools: List Mail Folders, List Messages, Search Messages
-Param: message_id: The ID of the message to move.
-Param: destination_folder_id: The ID of the folder to move the message into.
+Share Tools: List Mail Folders, List Emails, Search Emails
+Param: email_id: The ID of the email to move.
+Param: destination_folder_id: The ID of the folder to move the email into.
 
-#!${GPTSCRIPT_TOOL_DIR}/bin/gptscript-go-tool moveMessage
+#!${GPTSCRIPT_TOOL_DIR}/bin/gptscript-go-tool moveEmail
 
 ---
 Name: Current Email
-Description: Get the email address of the currently authenticated user.
+Description: Get the email address of the currently authenticated Outlook user.
 Share Context: Outlook Mail Context
 Credential: ../../credential
 
@@ -130,39 +130,39 @@ Credential: ../../credential
 
 ---
 Name: List Attachments
-Description: List the attachments of a message.
+Description: List the attachments of an Outlook email.
 Share Context: Outlook Mail Context
 Credential: ../../credential
-Share Tools: List Messages
-Param: message_id: The ID of the message to list attachments for.
+Share Tools: List Emails
+Param: email_id: The ID of the email to list attachments for.
 
 #!${GPTSCRIPT_TOOL_DIR}/bin/gptscript-go-tool listAttachments
 
 ---
 Name: Read Attachment
-Description: Get the markdown converted contents of an attachment from a given message.
+Description: Get the markdown converted contents of an attachment from an Outlook email.
 Share Context: Outlook Mail Context
 Credential: ../../credential
 Share Tools: List Attachments
-Param: message_id: The ID of the message to get the attachment from. Required.
+Param: email_id: The ID of the email to get the attachment from. Required.
 Param: attachment_id: The ID of the attachment to get. Required.
 
-#!${GPTSCRIPT_TOOL_DIR}/bin/gptscript-go-tool getAttachment
+#!${GPTSCRIPT_TOOL_DIR}/bin/gptscript-go-tool readAttachment
 
 ---
 Name: Download Attachment
-Description: Download an attachment into workspace from a message.
+Description: Download an attachment from an Outlook email into workspace.
 Share Context: Outlook Mail Context
 Credential: ../../credential
 Share Tools: List Attachments
-Param: message_id: The ID of the message to get the attachment from. Required.
+Param: email_id: The ID of the email to get the attachment from. Required.
 Param: attachment_id: The ID of the attachment to get. Required.
 
 #!${GPTSCRIPT_TOOL_DIR}/bin/gptscript-go-tool downloadAttachment
 
 ---
 Name: Delete Group Thread
-Description: Delete a group mailbox thread.
+Description: Delete a group mailbox thread in Outlook.
 Share Context: Outlook Mail Context
 Credential: ../../credential
 Share Tools: List Group Threads
@@ -173,7 +173,7 @@ Param: thread_id: The ID of the thread to delete.
 
 ---
 Name: List Groups
-Description: Lists all groups the user is a member of.
+Description: Lists all Microsoft 365 groups the user is a member of.
 Share Context: Outlook Mail Context
 Tools: github.com/gptscript-ai/datasets/filter
 Credential: ../../credential
@@ -182,7 +182,7 @@ Credential: ../../credential
 
 ---
 Name: List Group Threads
-Description: Lists all group mailbox threads in a Microsoft 365 group. This will also return messages in the threads.
+Description: Lists all group mailbox threads in a Microsoft 365 group. This will also return emails in the threads.
 Share Context: Outlook Mail Context
 Tools: github.com/gptscript-ai/datasets/filter
 Credential: ../../credential
@@ -195,39 +195,39 @@ Param: limit: (Optional) The maximum number of threads to return. If unset, retu
 #!${GPTSCRIPT_TOOL_DIR}/bin/gptscript-go-tool listGroupThreads
 
 ---
-Name: List Group Thread Message Attachments
-Description: Lists all attachments in a specific group thread message/post.
+Name: List Group Thread Email Attachments
+Description: Lists all attachments in a specific Outlook group thread email.
 Share Context: Outlook Mail Context
-Credential:../../credential
+Credential: ../../credential
 Share Tools: List Groups, List Group Threads
 Param: group_id: The ID of the group containing the thread.
-Param: thread_id: The ID of the thread containing the message.
-Param: post_id: The ID of the post/message to list attachments for.
+Param: thread_id: The ID of the thread containing the email.
+Param: email_id: The ID of the email to list attachments for.
 
-#!${GPTSCRIPT_TOOL_DIR}/bin/gptscript-go-tool listGroupThreadMessageAttachments
+#!${GPTSCRIPT_TOOL_DIR}/bin/gptscript-go-tool listGroupThreadEmailAttachments
 
 ---
-Name: Get Group Thread Message Attachment
-Description: Get the markdown converted contents of an attachment from a group thread message.
+Name: Get Group Thread Email Attachment
+Description: Get the markdown converted contents of an attachment from an Outlook group thread email.
 Share Context: Outlook Mail Context
-Credential:../../credential
-Share Tools: List Groups, List Group Threads, List Group Thread Message Attachments
+Credential: ../../credential
+Share Tools: List Groups, List Group Threads, List Group Thread Email Attachments
 Param: group_id: The ID of the group containing the thread.
-Param: thread_id: The ID of the thread containing the message.
-Param: post_id: The ID of the post/message containing the attachment.
+Param: thread_id: The ID of the thread containing the email.
+Param: email_id: The ID of the email containing the attachment.
 Param: attachment_id: The ID of the attachment to get.
 
-#!${GPTSCRIPT_TOOL_DIR}/bin/gptscript-go-tool getGroupThreadMessageAttachment
+#!${GPTSCRIPT_TOOL_DIR}/bin/gptscript-go-tool getGroupThreadEmailAttachment
 
 ---
-Name: Download Group Thread Message Attachment
-Description: Download an attachment from a group thread message/post into the workspace.
+Name: Download Group Thread Email Attachment
+Description: Download an attachment from an Outlook group thread email into the workspace.
 Share Context: Outlook Mail Context
-Credential:../../credential
-Share Tools: List Groups, List Group Threads, List Group Thread Message Attachments
+Credential: ../../credential
+Share Tools: List Groups, List Group Threads, List Group Thread Email Attachments
 Param: group_id: The ID of the group containing the thread.
-Param: thread_id: The ID of the thread containing the post.
-Param: post_id: The ID of the post containing the attachment.
+Param: thread_id: The ID of the thread containing the email.
+Param: email_id: The ID of the email containing the attachment.
 Param: attachment_id: The ID of the attachment to download.
 
 #!${GPTSCRIPT_TOOL_DIR}/bin/gptscript-go-tool downloadAttachment
@@ -242,14 +242,14 @@ Type: context
 
 You have access to tools for the Microsoft Outlook Mail API.
 
-Display the recieved and sent datetimes of all messages in the user's preferred timezone.
+Display the recieved and sent datetimes of all emails in the user's preferred timezone.
 When the user gives values for dates and times, assume they are in the user's preferred timezone unless otherwise specified by the user.
 When the user uses relative terms like "today", "tomorrow", or "last week", assume the date is the current day in the user's preferred timezone.
 
-Do not output mail folder IDs or message IDs because they are not helpful for the user. The message IDs are needed for getting message details, deleting a message, or moving a message.
-When printing a list of messages for the user, include the body preview. When printing a single message and its details, print the full body. Always include the email link.
-When printing a single message or a list of messages, use Markdown formatting.
-When creating a draft message, ensure the body is valid markdown and there are no broken links. Draft bodies may include markdown-compatible inline HTML for styling purposes.
+Do not output mail folder IDs or email IDs because they are not helpful for the user. The email IDs are needed for getting email details, deleting an email, or moving an email.
+When printing a list of emails for the user, include the body preview. When printing a single email and its details, print the full body. Always include the email link.
+When printing a single email or a list of emails, use Markdown formatting.
+When creating a draft email, ensure the body is valid markdown and there are no broken links. Draft bodies may include markdown-compatible inline HTML for styling purposes.
 
 If an email has an attachment, ask user whether they would like to read the attachment and add the contents to the context.
 
@@ -257,8 +257,8 @@ Only dowload the attachment if the user specifically asks to download it.
 
 Do not attempt to forward emails. Email forwarding is not supported.
 
-Before using the Create Group Thread Message tool, confirm the following with the user:
-- The subject and body of the message.
+Before using the Create Group Thread Email tool, confirm the following with the user:
+- The subject and body of the email.
 - Whether they want to reply to an existing thread or start a new one. If replying, which thread?
 - Whether they want to add additional recipients.
 - Whether they want to attach any files.


### PR DESCRIPTION
This replaces the words "message" and "post" with "email" throughout all the Outlook Mail tools, as that should be less confusing for the user and for the LLM. I also made sure to mention something about Outlook or MS365 in the descriptions for each of these tools.