### PR TITLE
fix: include tzdata for golang timezone

### DIFF
--- a/microsoft365/outlook/calendar/main.go
+++ b/microsoft365/outlook/calendar/main.go
@@ -34,8 +34,9 @@ func main() {
 		}
 		loc, err := time.LoadLocation(timezone)
 		if err != nil {
-			fmt.Println("Error loading user timezone: %s. Error: %s. Falling back to UTC.", timezone, err)
+			fmt.Printf("Error loading user timezone: %s. Error: %v. Falling back to UTC.\n", timezone, err)
 			timezone = "UTC"
+			loc = time.UTC // Use UTC location after error
 		}
 		now := time.Now().In(loc)
 		start := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, loc)

--- a/microsoft365/outlook/calendar/main.go
+++ b/microsoft365/outlook/calendar/main.go
@@ -34,8 +34,8 @@ func main() {
 		}
 		loc, err := time.LoadLocation(timezone)
 		if err != nil {
-			fmt.Println("Error loading location: %s. Error: %s", timezone, err)
-			os.Exit(1)
+			fmt.Println("Error loading user timezone: %s. Error: %s. Falling back to UTC.", timezone, err)
+			timezone = "UTC"
 		}
 		now := time.Now().In(loc)
 		start := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, loc)

--- a/microsoft365/outlook/calendar/main.go
+++ b/microsoft365/outlook/calendar/main.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	_ "time/tzdata"
 
 	"github.com/obot-platform/tools/microsoft365/outlook/calendar/pkg/commands"
 	"github.com/obot-platform/tools/microsoft365/outlook/calendar/pkg/graph"

--- a/microsoft365/outlook/calendar/pkg/printers/events.go
+++ b/microsoft365/outlook/calendar/pkg/printers/events.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"strings"
 	"time"
+	_ "time/tzdata"
 )
 
 func EventToString(ctx context.Context, client *msgraphsdkgo.GraphServiceClient, calendar graph.CalendarInfo, event models.Eventable) string {


### PR DESCRIPTION
fix the bug sangeetha found https://github.com/obot-platform/obot/issues/2644#issuecomment-2831604273
and https://github.com/obot-platform/obot/issues/2643

Timezone database information is often not available in minimal Docker environment operating systems, so it needs to be imported into the Go binary using import _ \"time/tzdata\".