### PR TITLE
enhance: update model providers to support personal tokens

### DIFF
--- a/anthropic-model-provider-go/main.go
+++ b/anthropic-model-provider-go/main.go
@@ -14,15 +14,11 @@ func main() {
 	isValidate := len(os.Args) > 1 && os.Args[1] == "validate"
 
 	cfg := &proxy.Config{
-		APIKey:     os.Getenv("OBOT_ANTHROPIC_MODEL_PROVIDER_API_KEY"), // optional, as e.g. Ollama doesn't require an API key
-		ListenPort: os.Getenv("PORT"),
-		BaseURL:    "https://api.anthropic.com/v1/",
-		RewriteHeaderFn: func(header http.Header) {
-			header.Del("Authorization")
-			header.Set("x-api-key", os.Getenv("OBOT_ANTHROPIC_MODEL_PROVIDER_API_KEY"))
-			header.Set("anthropic-version", "2023-06-01")
-		},
-		Name: "Anthropic",
+		APIKey:               os.Getenv("OBOT_ANTHROPIC_MODEL_PROVIDER_API_KEY"),
+		PersonalAPIKeyHeader: "X-Obot-OBOT_ANTHROPIC_MODEL_PROVIDER_API_KEY",
+		ListenPort:           os.Getenv("PORT"),
+		BaseURL:              "https://api.anthropic.com/v1/",
+		Name:                 "Anthropic",
 	}
 
 	prox := aproxy.NewServer(cfg)
@@ -38,8 +34,10 @@ func main() {
 		"/v1/":       reverseProxy.ServeHTTP,
 	}
 
-	if err := cfg.Validate("/tools/anthropic-model-provider/validate"); err != nil {
-		os.Exit(1)
+	if cfg.APIKey != "" {
+		if err := cfg.Validate("/tools/anthropic-model-provider/validate"); err != nil {
+			os.Exit(1)
+		}
 	}
 
 	if isValidate {

--- a/anthropic-model-provider-go/proxy/proxy.go
+++ b/anthropic-model-provider-go/proxy/proxy.go
@@ -28,8 +28,14 @@ func (s *Server) AnthropicProxyRedirect(req *http.Request) {
 	req.URL.Path = s.cfg.URL.JoinPath(strings.TrimPrefix(req.URL.Path, "/v1")).Path
 	req.Host = req.URL.Host
 
+	apiKey := s.cfg.APIKey
+	fmt.Println(req.Header)
+	if requestAPIKey := req.Header.Get("X-Obot-OBOT_ANTHROPIC_MODEL_PROVIDER_API_KEY"); requestAPIKey != "" {
+		apiKey = requestAPIKey
+		req.Header.Del("X-Obot-OBOT_ANTHROPIC_MODEL_PROVIDER_API_KEY")
+	}
 	req.Header.Del("Authorization")
-	req.Header.Set("x-api-key", s.cfg.APIKey)
+	req.Header.Set("x-api-key", apiKey)
 	req.Header.Set("anthropic-version", "2023-06-01")
 
 	if req.Body == nil || s.cfg.URL.Host != AnthropicBaseHostName || req.URL.Path != proxy.ChatCompletionsPath {

--- a/deepseek-model-provider/main.go
+++ b/deepseek-model-provider/main.go
@@ -10,16 +10,16 @@ import (
 func main() {
 	apiKey := os.Getenv("OBOT_DEEPSEEK_MODEL_PROVIDER_API_KEY")
 	if apiKey == "" {
-		fmt.Fprintln(os.Stderr, "OBOT_DEEPSEEK_MODEL_PROVIDER_API_KEY environment variable not set")
-		os.Exit(1)
+		fmt.Println("OBOT_DEEPSEEK_MODEL_PROVIDER_API_KEY is not set, credential must be provided on a per-request basis")
 	}
 
 	cfg := &proxy.Config{
-		APIKey:          apiKey,
-		ListenPort:      os.Getenv("PORT"),
-		BaseURL:         "https://api.deepseek.com/v1",
-		RewriteModelsFn: proxy.RewriteAllModelsWithUsage("llm"),
-		Name:            "DeepSeek",
+		APIKey:               apiKey,
+		PersonalAPIKeyHeader: "X-Obot-OBOT_DEEPSEEK_MODEL_PROVIDER_API_KEY",
+		ListenPort:           os.Getenv("PORT"),
+		BaseURL:              "https://api.deepseek.com/v1",
+		RewriteModelsFn:      proxy.RewriteAllModelsWithUsage("llm"),
+		Name:                 "DeepSeek",
 	}
 
 	if len(os.Args) > 1 && os.Args[1] == "validate" {

--- a/generic-openai-model-provider/main.go
+++ b/generic-openai-model-provider/main.go
@@ -14,9 +14,7 @@ func main() {
 
 	baseURL := os.Getenv("OBOT_GENERIC_OPENAI_MODEL_PROVIDER_BASE_URL")
 	if baseURL == "" {
-		fmt.Fprintln(os.Stderr, "OBOT_GENERIC_OPENAI_MODEL_PROVIDER_BASE_URL environment variable not set")
-		fmt.Printf("{ \"error\": \"BaseURL is required\" }\n")
-		os.Exit(1)
+		fmt.Println("OBOT_GENERIC_OPENAI_MODEL_PROVIDER_BASE_URL environment variable not set, credential must be provided on a per-request basis")
 	}
 
 	u, err := url.Parse(strings.TrimRight(baseURL, "/"))
@@ -35,11 +33,12 @@ func main() {
 	}
 
 	cfg := &proxy.Config{
-		APIKey:          os.Getenv("OBOT_GENERIC_OPENAI_MODEL_PROVIDER_API_KEY"), // optional, as e.g. Ollama doesn't require an API key
-		ListenPort:      os.Getenv("PORT"),
-		BaseURL:         u.String(),
-		RewriteModelsFn: proxy.RewriteAllModelsWithUsage("llm"),
-		Name:            "Generic OpenAI",
+		APIKey:               os.Getenv("OBOT_GENERIC_OPENAI_MODEL_PROVIDER_API_KEY"), // optional, as e.g. Ollama doesn't require an API key
+		PersonalAPIKeyHeader: "X-Obot-OBOT_GENERIC_OPENAI_MODEL_PROVIDER_API_KEY",
+		ListenPort:           os.Getenv("PORT"),
+		BaseURL:              u.String(),
+		RewriteModelsFn:      proxy.RewriteAllModelsWithUsage("llm"),
+		Name:                 "Generic OpenAI",
 	}
 
 	if err := cfg.Validate("/tools/generic-openai-model-provider/validate"); err != nil {

--- a/groq-model-provider/main.go
+++ b/groq-model-provider/main.go
@@ -10,16 +10,16 @@ import (
 func main() {
 	apiKey := os.Getenv("OBOT_GROQ_MODEL_PROVIDER_API_KEY")
 	if apiKey == "" {
-		fmt.Fprintln(os.Stderr, "OBOT_GROQ_MODEL_PROVIDER_API_KEY environment variable not set")
-		os.Exit(1)
+		fmt.Println("OBOT_GROQ_MODEL_PROVIDER_API_KEY is not set, credential must be provided on a per-request basis")
 	}
 
 	cfg := &proxy.Config{
-		APIKey:          apiKey,
-		ListenPort:      os.Getenv("PORT"),
-		BaseURL:         "https://api.groq.com/openai/v1",
-		RewriteModelsFn: proxy.RewriteAllModelsWithUsage("llm"),
-		Name:            "Groq",
+		APIKey:               apiKey,
+		PersonalAPIKeyHeader: "X-Obot-OBOT_GROQ_MODEL_PROVIDER_API_KEY",
+		ListenPort:           os.Getenv("PORT"),
+		BaseURL:              "https://api.groq.com/openai/v1",
+		RewriteModelsFn:      proxy.RewriteAllModelsWithUsage("llm"),
+		Name:                 "Groq",
 	}
 
 	if len(os.Args) > 1 && os.Args[1] == "validate" {

--- a/ollama-model-provider/main.go
+++ b/ollama-model-provider/main.go
@@ -39,11 +39,11 @@ func main() {
 	}
 
 	cfg := &proxy.Config{
-		APIKey:          "",
-		ListenPort:      os.Getenv("PORT"),
-		BaseURL:         u.String(),
-		RewriteModelsFn: proxy.RewriteAllModelsWithUsage("llm"),
-		Name:            "Ollama",
+		PersonalBaseURLHeader: "X-Obot-OLLAMA_MODEL_PROVIDER_HOST",
+		ListenPort:            os.Getenv("PORT"),
+		BaseURL:               u.String(),
+		RewriteModelsFn:       proxy.RewriteAllModelsWithUsage("llm"),
+		Name:                  "Ollama",
 	}
 
 	if len(os.Args) > 1 && os.Args[1] == "validate" {

--- a/openai-model-provider/openaiproxy/proxy.go
+++ b/openai-model-provider/openaiproxy/proxy.go
@@ -26,7 +26,12 @@ func (s *Server) Openaiv1ProxyRedirect(req *http.Request) {
 	req.URL.Path = s.cfg.URL.JoinPath(strings.TrimPrefix(req.URL.Path, "/v1")).Path // join baseURL with request path - /v1 must be part of baseURL if it's needed
 	req.Host = req.URL.Host
 
-	req.Header.Set("Authorization", "Bearer "+s.cfg.APIKey)
+	apiKey := s.cfg.APIKey
+	if requestAPIKey := req.Header.Get("X-Obot-OBOT_OPENAI_MODEL_PROVIDER_API_KEY"); requestAPIKey != "" {
+		apiKey = requestAPIKey
+		req.Header.Del("X-Obot-OBOT_OPENAI_MODEL_PROVIDER_API_KEY")
+	}
+	req.Header.Set("Authorization", "Bearer "+apiKey)
 
 	if req.Body == nil || s.cfg.URL.Host != proxy.OpenaiBaseHostName || req.URL.Path != proxy.ChatCompletionsPath {
 		return

--- a/placeholder-credential/main.py
+++ b/placeholder-credential/main.py
@@ -5,10 +5,9 @@ from gptscript import GPTScript, Options
 
 
 if os.getenv("OBOT_RUN_ID") is not None:
-    # This is being run from Obot, and we shouldn't prompt for the credential.
-    # The credential should have been set up outside of this, so just error.
-    print("The credential has not been properly configured")
-    exit(1)
+	# This is being run by Obot. This credential being called means that a "global" credential has not been setup,
+	# but that a user is trying to use it for their own Obot with their own credentials.
+    exit(0)
 
 if os.getenv("ENV_VARS") is None:
     print("No environment variables provided for prompting")

--- a/vllm-model-provider/main.go
+++ b/vllm-model-provider/main.go
@@ -16,14 +16,12 @@ func cleanURL(endpoint string) string {
 func main() {
 	apiKey := os.Getenv("OBOT_VLLM_MODEL_PROVIDER_API_KEY")
 	if apiKey == "" {
-		fmt.Fprintln(os.Stderr, "OBOT_VLLM_MODEL_PROVIDER_API_KEY environment variable not set")
-		os.Exit(1)
+		fmt.Println("OBOT_VLLM_MODEL_PROVIDER_API_KEY environment variable not set, credential must be provided on a per-request basis")
 	}
 
 	endpoint := os.Getenv("OBOT_VLLM_MODEL_PROVIDER_ENDPOINT")
 	if endpoint == "" {
-		fmt.Fprintln(os.Stderr, "OBOT_VLLM_MODEL_PROVIDER_ENDPOINT environment variable not set")
-		os.Exit(1)
+		fmt.Println("OBOT_VLLM_MODEL_PROVIDER_ENDPOINT environment variable not set, credential must be provided on a per-request basis")
 	}
 
 	endpoint = cleanURL(endpoint)
@@ -42,11 +40,13 @@ func main() {
 	}
 
 	cfg := &proxy.Config{
-		APIKey:          apiKey,
-		ListenPort:      os.Getenv("PORT"),
-		BaseURL:         strings.TrimSuffix(u.String(), "/v1") + "/v1", // make sure we have /v1 for vLLM
-		RewriteModelsFn: proxy.RewriteAllModelsWithUsage("llm"),
-		Name:            "vLLM",
+		APIKey:                apiKey,
+		PersonalAPIKeyHeader:  "X-Obot-OBOT_VLLM_MODEL_PROVIDER_API_KEY",
+		PersonalBaseURLHeader: "X-Obot-OBOT_VLLM_MODEL_PROVIDER_ENDPOINT",
+		ListenPort:            os.Getenv("PORT"),
+		BaseURL:               strings.TrimSuffix(u.String(), "/v1") + "/v1", // make sure we have /v1 for vLLM
+		RewriteModelsFn:       proxy.RewriteAllModelsWithUsage("llm"),
+		Name:                  "vLLM",
 	}
 
 	if len(os.Args) > 1 && os.Args[1] == "validate" {

--- a/xai-model-provider/main.go
+++ b/xai-model-provider/main.go
@@ -20,16 +20,16 @@ func RewriteGrokModels(resp *http.Response) error {
 func main() {
 	apiKey := os.Getenv("OBOT_XAI_MODEL_PROVIDER_API_KEY")
 	if apiKey == "" {
-		fmt.Fprintln(os.Stderr, "OBOT_XAI_MODEL_PROVIDER_API_KEY environment variable not set")
-		os.Exit(1)
+		fmt.Println("OBOT_XAI_MODEL_PROVIDER_API_KEY is not set, credential must be provided on a per-request basis")
 	}
 
 	cfg := &proxy.Config{
-		APIKey:          apiKey,
-		ListenPort:      os.Getenv("PORT"),
-		BaseURL:         "https://api.x.ai/v1",
-		RewriteModelsFn: RewriteGrokModels,
-		Name:            "xAI",
+		APIKey:               apiKey,
+		PersonalAPIKeyHeader: "X-Obot-OBOT_XAI_MODEL_PROVIDER_API_KEY",
+		ListenPort:           os.Getenv("PORT"),
+		BaseURL:              "https://api.x.ai/v1",
+		RewriteModelsFn:      RewriteGrokModels,
+		Name:                 "xAI",
 	}
 
 	if len(os.Args) > 1 && os.Args[1] == "validate" {


### PR DESCRIPTION
The model providers have been changed to support user's personal tokens. If configuration for the environment variables has been provided via special headers, then the model providers will use that configuration instead of the "global" configuration. Additionally, the model providers have been changed to be able to start up without configuration so that they can be used only with a user's individual configuration.