### PR TITLE
fix: OneDrive tool fixes

### DIFF
--- a/microsoft365/onedrive/main.go
+++ b/microsoft365/onedrive/main.go
@@ -24,8 +24,8 @@ func main() {
 		mainErr = commands.GetDrive(context.Background(), os.Getenv("DRIVE_ID"))
 	case "listDriveItems":
 		mainErr = commands.ListDriveItems(context.Background(), os.Getenv("DRIVE_ID"), os.Getenv("FOLDER_ID"))
-	case "listSharedItems":
-		mainErr = commands.ListSharedItems(context.Background())
+	case "listSharedWithMeItems":
+		mainErr = commands.ListSharedWithMeItems(context.Background())
 	case "getDriveItem":
 		mainErr = commands.GetDriveItem(context.Background(), os.Getenv("DRIVE_ID"), os.Getenv("ITEM_ID"))
 	case "updateDriveItem":

--- a/microsoft365/onedrive/pkg/commands/addPermission.go
+++ b/microsoft365/onedrive/pkg/commands/addPermission.go
@@ -25,7 +25,7 @@ func AddPermission(ctx context.Context, driveID string, itemID string, emails st
 		}
 	}
 
-	validRoles := []string{"read", "write", "review", "owner"}
+	validRoles := []string{"read", "write", "member", "owner"}
 	if !slices.Contains(validRoles, role) {
 		return fmt.Errorf("invalid role: %s, valid roles are: %s", role, strings.Join(validRoles, ", "))
 	}

--- a/microsoft365/onedrive/pkg/commands/listSharedWithMeItems.go
+++ b/microsoft365/onedrive/pkg/commands/listSharedWithMeItems.go
@@ -11,13 +11,13 @@ import (
 	"github.com/obot-platform/tools/microsoft365/onedrive/pkg/util"
 )
 
-func ListSharedItems(ctx context.Context) error {
+func ListSharedWithMeItems(ctx context.Context) error {
 	c, err := client.NewClient(global.AllScopes)
 	if err != nil {
 		return fmt.Errorf("failed to create client: %w", err)
 	}
 
-	items, err := graph.ListSharedDriveItems(ctx, c)
+	items, err := graph.ListSharedWithMeDriveItems(ctx, c)
 	if err != nil {
 		return fmt.Errorf("failed to list shared items: %w", err)
 	}
@@ -31,20 +31,15 @@ func ListSharedItems(ctx context.Context) error {
 	for _, item := range items {
 		itemStr := ""
 		itemStr += fmt.Sprintf("FileName: %s\n", util.Deref(item.GetName()))
-		if parentRef := item.GetParentReference(); parentRef != nil {
-			if driveId := parentRef.GetDriveId(); driveId != nil {
-				itemStr += fmt.Sprintf("Drive ID: %s\n", util.Deref(driveId))
-			}
-		}
+
 		itemStr += fmt.Sprintf("Item ID: %s\n", util.Deref(item.GetId()))
 
-		if shared := item.GetShared(); shared != nil {
-			if owner := shared.GetOwner(); owner != nil {
-				if user := owner.GetUser(); user != nil {
-					itemStr += fmt.Sprintf("Shared by: %s\n", util.Deref(user.GetDisplayName()))
+		if remoteItem := item.GetRemoteItem(); remoteItem != nil {
+			if parentRef := remoteItem.GetParentReference(); parentRef != nil {
+				if parentDriveID := parentRef.GetDriveId(); parentDriveID != nil {
+					itemStr += fmt.Sprintf("Drive ID: %s\n", util.Deref(parentDriveID))
 				}
 			}
-			itemStr += fmt.Sprintf("Sharing Scope: %s\n", util.Deref(shared.GetScope()))
 		}
 
 		if webUrl := item.GetWebUrl(); webUrl != nil {

--- a/microsoft365/onedrive/pkg/graph/driveItem.go
+++ b/microsoft365/onedrive/pkg/graph/driveItem.go
@@ -29,9 +29,14 @@ func ListDriveItems(ctx context.Context, client *msgraphsdkgo.GraphServiceClient
 	return resp.GetValue(), nil
 }
 
-func ListSharedDriveItems(ctx context.Context, client *msgraphsdkgo.GraphServiceClient) ([]models.DriveItemable, error) {
-	sharedWithMe, err := client.Drives().ByDriveId("me").SharedWithMe().GetAsSharedWithMeGetResponse(ctx, nil)
+func ListSharedWithMeDriveItems(ctx context.Context, client *msgraphsdkgo.GraphServiceClient) ([]models.DriveItemable, error) {
+	drive, err := client.Me().Drive().Get(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get user drive: %w", err)
+	}
 
+	driveID := *drive.GetId()
+	sharedWithMe, err := client.Drives().ByDriveId(driveID).SharedWithMe().GetAsSharedWithMeGetResponse(ctx, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list shared items: %w", err)
 	}

--- a/microsoft365/onedrive/pkg/printer/printDrive.go
+++ b/microsoft365/onedrive/pkg/printer/printDrive.go
@@ -12,6 +12,9 @@ func PrintDrive(drive models.Driveable, details bool) {
 	if driveType := drive.GetDriveType(); driveType != nil {
 		fmt.Printf("Drive Type: %s\n", *driveType)
 	}
+	if webUrl := drive.GetWebUrl(); webUrl != nil {
+		fmt.Printf("Web URL: %s\n", *webUrl)
+	}
 	if owner := drive.GetOwner(); owner != nil {
 		user := owner.GetUser()
 		if user != nil && user.GetDisplayName() != nil {

--- a/microsoft365/onedrive/tool.gpt
+++ b/microsoft365/onedrive/tool.gpt
@@ -2,7 +2,7 @@
 Name: Microsoft 365 OneDrive
 Description: Tools for interacting with Microsoft 365 OneDrive.
 Metadata: bundle: true
-Share Tools: List Drive Files, Create Folder, List All Drives, Get Drive, List Shared Files, Get File, Delete File, Copy File, Download File, Upload File, Move and Rename File, List Permissions, Add Permission, Delete Permission
+Share Tools: List Drive Files, Create Folder, List All Drives, Get Drive, List SharedWithMe Files, Get File, Delete File, Copy File, Download File, Upload File, Move and Rename File, List Permissions, Add Permission, Delete Permission
 
 ---
 Name: List Drive Files
@@ -45,13 +45,13 @@ Param: drive_id: (Optional) The ID of the drive to get details about. If unset, 
 #!${GPTSCRIPT_TOOL_DIR}/bin/gptscript-go-tool getDrive
 
 ---
-Name: List Shared Files
-Description: Lists all shared files for a user.
+Name: List SharedWithMe Files
+Description: Lists all files and folders that have been shared with the user by others. Does not include items the user has shared with others.
 Share Context: OneDrive Context
 Tools: github.com/gptscript-ai/datasets/filter
 Credential: ../credential
 
-#!${GPTSCRIPT_TOOL_DIR}/bin/gptscript-go-tool listSharedItems
+#!${GPTSCRIPT_TOOL_DIR}/bin/gptscript-go-tool listSharedWithMeItems
 
 ---
 Name: Copy File
@@ -128,7 +128,7 @@ Credential: ../credential
 Param: drive_id: (Required) The ID of the drive to add the permission to.
 Param: item_id: (Required) The ID of the item to add the permission to.
 Param: emails: (Required) Comma-separated list of email addresses to grant permission to (e.g., "user1@example.com,user2@example.com")
-Param: role: (Required) The role to grant to the users. Must be one of: "read" (view only), "write" (view and edit), "review" (view and approve), or "owner" (full control including sharing).
+Param: role: (Required) The role to grant to the users. Must be one of: "read" (view only), "write" (view and edit), "member" (the member role for SharePoint and OneDrive for Business), or "owner" (the owner role for SharePoint and OneDrive for Business).
 Param: message: (Optional) The message to send to the users.
 Param: password: (Optional) The password to use for the permission. if unset, the permission will be added without a password.
 Param: expiration_date_time: (Optional) The expiration date and time of the permission. if unset, the permission will be added without an expiration date. Format: YYYY-MM-DDTHH:MM:SSZ, like 2018-07-15T14:00:00.000Z
@@ -168,6 +168,8 @@ Share Context: ../../time
 You have access to tools for the Microsoft 365 OneDrive API.
 
 Show the URL of drives or files in markdown format: [description](URL)
+
+Don't display any IDs in your response to the user, unless explicitly asked for.
 
 ## End of instructions for using the Microsoft 365 OneDrive tools
 


### PR DESCRIPTION
- display information for sharedwithme Items. show driveID so can be used for downloading. this is for [this ](https://github.com/obot-platform/obot/issues/2861) and [this](https://github.com/obot-platform/obot/issues/2861)
- print  drive's web URL. [issue](https://github.com/obot-platform/obot/issues/2870)
- add permissions with right roles. for [this](https://github.com/obot-platform/obot/issues/2863)