### PR TITLE
fix: outlook: fix credential on getting group email attachments

### DIFF
--- a/microsoft365/outlook/mail/tool.gpt
+++ b/microsoft365/outlook/mail/tool.gpt
@@ -212,7 +212,7 @@ Param: email_id: The ID of the email to list attachments for.
 Name: Get Group Thread Email Attachment
 Description: Get the markdown converted contents of an attachment from an Outlook group thread email.
 Share Context: Outlook Mail Context
-Credential: sys.model.provider.credential
+Credential: ../../credential
 Share Tools: List Groups, List Group Threads, List Group Thread Email Attachments
 Param: group_id: The ID of the group containing the thread.
 Param: thread_id: The ID of the thread containing the email.

--- a/microsoft365/outlook/mail/tool.gpt
+++ b/microsoft365/outlook/mail/tool.gpt
@@ -213,6 +213,7 @@ Name: Get Group Thread Email Attachment
 Description: Get the markdown converted contents of an attachment from an Outlook group thread email.
 Share Context: Outlook Mail Context
 Credential: ../../credential
+Credential: sys.model.provider.credential
 Share Tools: List Groups, List Group Threads, List Group Thread Email Attachments
 Param: group_id: The ID of the group containing the thread.
 Param: thread_id: The ID of the thread containing the email.


### PR DESCRIPTION
Looks like this line got accidentally changed/removed a little while ago.

for https://github.com/obot-platform/obot/issues/2759