### PR TITLE
fix: memory tool causes 403s on local-authenticate

### DIFF
--- a/memory/main.go
+++ b/memory/main.go
@@ -79,7 +79,7 @@ func delete(ctx context.Context, c *apiclient.Client, projectID string) error {
 
 func list(ctx context.Context, c *apiclient.Client, projectID string) error {
 	result, err := c.ListMemories(ctx, assistantID, projectID)
-	if err != nil && !strings.Contains(err.Error(), "404") {
+	if err != nil && !strings.Contains(err.Error(), "404") && !strings.Contains(err.Error(), "403") {
 		return fmt.Errorf("failed to list memories: %v", err)
 	}
 


### PR DESCRIPTION
Ignore 403 errors when listing memories to prevent it from causing
local-authenticate calls from failing.

Addresses https://github.com/obot-platform/obot/issues/2931

