### PR TITLE
Chore: Drop google search tools

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -31,8 +31,6 @@ tools:
     reference: ./google/docs
   google-gmail:
     reference: ./google/gmail
-  google-search:
-    reference: ./google/search
   google-search-console:
     reference: ./google/search-console
   google-sheets:
@@ -69,8 +67,6 @@ tools:
     reference: ./shell
   tavily:
     reference: ./search/tavily
-  googlecustomsearch:
-    reference: ./search/google/googlecustomsearch
   pagerduty:
     reference: ./pagerduty
   postgres:


### PR DESCRIPTION
Dropping google-search (browser based search) and googlecustomsearch
from the index because we dont want to expose these in our MCP server
catalog. I didnt delete the code for these tools becasue I think its
useful to keep them around. Like, you could added the google-search
locally as a custom tool so that it shows up for you locally.

Signed-off-by: Craig Jellick <craig@acorn.io>
