### PR TITLE
enhance: outlook mail: add tool to download files from onedrive share links

### DIFF
--- a/microsoft365/outlook/mail/main.go
+++ b/microsoft365/outlook/mail/main.go
@@ -6,9 +6,9 @@ import (
 	"os"
 	"strings"
 
+	"github.com/obot-platform/obot/apiclient"
 	"github.com/obot-platform/tools/microsoft365/outlook/mail/pkg/commands"
 	"github.com/obot-platform/tools/microsoft365/outlook/mail/pkg/graph"
-	"github.com/obot-platform/obot/apiclient"
 )
 
 var (
@@ -155,6 +155,11 @@ func main() {
 			os.Getenv("ATTACHMENT_ID"),
 		); err != nil {
 			fmt.Printf("failed to get group thread email attachment: %v\n", err)
+			os.Exit(1)
+		}
+	case "downloadOneDriveShareLink":
+		if err := commands.DownloadOneDriveShareLink(context.Background(), os.Getenv("SHARE_LINK")); err != nil {
+			fmt.Printf("failed to download OneDrive share link: %v\n", err)
 			os.Exit(1)
 		}
 	default:

--- a/microsoft365/outlook/mail/pkg/commands/downloadOneDriveShareLink.go
+++ b/microsoft365/outlook/mail/pkg/commands/downloadOneDriveShareLink.go
@@ -1,0 +1,36 @@
+package commands
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+
+	"github.com/gptscript-ai/go-gptscript"
+	"github.com/obot-platform/tools/microsoft365/outlook/mail/pkg/client"
+	"github.com/obot-platform/tools/microsoft365/outlook/mail/pkg/global"
+	"github.com/obot-platform/tools/microsoft365/outlook/mail/pkg/graph"
+)
+
+func DownloadOneDriveShareLink(ctx context.Context, shareLink string) error {
+	c, err := client.NewClient(global.AllScopes)
+	if err != nil {
+		return fmt.Errorf("failed to create client: %w", err)
+	}
+
+	filename, content, err := graph.GetOneDriveShareLink(ctx, c, shareLink)
+	if err != nil {
+		return fmt.Errorf("failed to get content of shared drive item: %w", err)
+	}
+
+	gs, err := gptscript.NewGPTScript()
+	if err != nil {
+		return fmt.Errorf("failed to create GPTScript client: %w", err)
+	}
+
+	if err := gs.WriteFileInWorkspace(ctx, filepath.Join("files", filename), content); err != nil {
+		return fmt.Errorf("failed to write file to workspace: %w", err)
+	}
+
+	fmt.Printf("Successfully downloaded %s to workspace\n", filename)
+	return nil
+}

--- a/microsoft365/outlook/mail/pkg/global/global.go
+++ b/microsoft365/outlook/mail/pkg/global/global.go
@@ -3,6 +3,6 @@ package global
 const CredentialEnv = "GPTSCRIPT_GRAPH_MICROSOFT_COM_BEARER_TOKEN"
 
 var (
-	ReadOnlyScopes = []string{"Mail.Read", "User.Read", "MailboxSettings.Read", "Groups.Read.All"}
-	AllScopes      = []string{"Mail.Read", "Mail.ReadWrite", "Mail.Send", "User.Read", "MailboxSettings.Read", "Groups.ReadWrite.All"}
+	ReadOnlyScopes = []string{"Mail.Read", "User.Read", "MailboxSettings.Read", "Groups.Read.All", "Files.Read.All"}
+	AllScopes      = []string{"Mail.Read", "Mail.ReadWrite", "Mail.Send", "User.Read", "MailboxSettings.Read", "Groups.ReadWrite.All", "Files.ReadWrite.All"}
 )

--- a/microsoft365/outlook/mail/pkg/graph/shares.go
+++ b/microsoft365/outlook/mail/pkg/graph/shares.go
@@ -1,0 +1,39 @@
+package graph
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"strings"
+
+	msgraphsdkgo "github.com/microsoftgraph/msgraph-sdk-go"
+	"github.com/obot-platform/tools/microsoft365/outlook/mail/pkg/util"
+)
+
+func convertShareLinkToID(shareLink string) string {
+	// See https://learn.microsoft.com/en-us/graph/api/shares-get?view=graph-rest-1.0&tabs=http#encoding-sharing-urls
+	encodedLink := base64.StdEncoding.EncodeToString([]byte(shareLink))
+	encodedLink = strings.TrimRight(encodedLink, "=")
+	encodedLink = strings.ReplaceAll(encodedLink, "/", "_")
+	encodedLink = strings.ReplaceAll(encodedLink, "+", "-")
+	return fmt.Sprintf("u!%s", encodedLink)
+}
+
+func GetOneDriveShareLink(ctx context.Context, client *msgraphsdkgo.GraphServiceClient, shareLink string) (string, []byte, error) {
+	item, err := client.Shares().BySharedDriveItemId(convertShareLinkToID(shareLink)).DriveItem().Get(ctx, nil)
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to get shared drive item: %w", err)
+	}
+
+	content, err := client.Shares().BySharedDriveItemId(convertShareLinkToID(shareLink)).DriveItem().Content().Get(ctx, nil)
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to get content of shared drive item: %w", err)
+	}
+
+	fileName := util.Deref(item.GetName())
+	if fileName == "" {
+		return "", nil, fmt.Errorf("shared drive item has no file name")
+	}
+
+	return fileName, content, nil
+}

--- a/microsoft365/outlook/mail/pkg/graph/shares.go
+++ b/microsoft365/outlook/mail/pkg/graph/shares.go
@@ -20,12 +20,14 @@ func convertShareLinkToID(shareLink string) string {
 }
 
 func GetOneDriveShareLink(ctx context.Context, client *msgraphsdkgo.GraphServiceClient, shareLink string) (string, []byte, error) {
-	item, err := client.Shares().BySharedDriveItemId(convertShareLinkToID(shareLink)).DriveItem().Get(ctx, nil)
+	id := convertShareLinkToID(shareLink)
+
+	item, err := client.Shares().BySharedDriveItemId(id).DriveItem().Get(ctx, nil)
 	if err != nil {
 		return "", nil, fmt.Errorf("failed to get shared drive item: %w", err)
 	}
 
-	content, err := client.Shares().BySharedDriveItemId(convertShareLinkToID(shareLink)).DriveItem().Content().Get(ctx, nil)
+	content, err := client.Shares().BySharedDriveItemId(id).DriveItem().Content().Get(ctx, nil)
 	if err != nil {
 		return "", nil, fmt.Errorf("failed to get content of shared drive item: %w", err)
 	}

--- a/microsoft365/outlook/mail/tool.gpt
+++ b/microsoft365/outlook/mail/tool.gpt
@@ -3,7 +3,7 @@ Name: Outlook Mail
 Description: Create, read, send, and manage emails in Outlook Mail in Microsoft 365
 Metadata: bundle: true
 Metadata: mcp: true
-Share Tools: List Mail Folders, List Emails, Get Email Details, Search Emails, Create Draft, Create Group Thread Email, Send Draft, Delete Email, Move Email, List Groups, List Group Threads, Delete Group Thread, Current Email, List Attachments, Download Attachment, Read Attachment, List Group Thread Email Attachments, Get Group Thread Email Attachment, Download Group Thread Email Attachment
+Share Tools: List Mail Folders, List Emails, Get Email Details, Search Emails, Create Draft, Create Group Thread Email, Send Draft, Delete Email, Move Email, List Groups, List Group Threads, Delete Group Thread, Current Email, List Attachments, Download Attachment, Read Attachment, List Group Thread Email Attachments, Get Group Thread Email Attachment, Download Group Thread Email Attachment, Download OneDrive Share Link
 
 ---
 Name: List Mail Folders
@@ -235,6 +235,15 @@ Param: email_id: The ID of the email containing the attachment.
 Param: attachment_id: The ID of the attachment to download.
 
 #!${GPTSCRIPT_TOOL_DIR}/bin/gptscript-go-tool downloadAttachment
+
+---
+Name: Download OneDrive Share Link
+Description: Download the file from a OneDrive share link to the workspace
+Share Context: Outlook Mail Context
+Credential: ../../credential
+Param: share_link: The OneDrive share link
+
+#!${GPTSCRIPT_TOOL_DIR}/bin/gptscript-go-tool downloadOneDriveShareLink
 
 ---
 Name: Outlook Mail Context


### PR DESCRIPTION
for https://github.com/obot-platform/obot/issues/2625

Since these "OneDrive attachments" that can appear in emails are actually just OneDrive share links, I added a tool to the Outlook Mail bundle to download them, the same way we download normal files in the OneDrive tools.