### PR TITLE
fix: Outlook calendar list events

### DIFF
--- a/microsoft365/outlook/calendar/main.go
+++ b/microsoft365/outlook/calendar/main.go
@@ -41,7 +41,7 @@ func main() {
 		now := time.Now().In(loc)
 		start := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, loc)
 		end := time.Date(now.Year(), now.Month(), now.Day(), 23, 59, 59, 0, loc)
-		if err := commands.ListEvents(context.Background(), start, end); err != nil {
+		if err := commands.ListEvents(context.Background(), "", start, end, ""); err != nil {
 			fmt.Println(err)
 			os.Exit(1)
 		}
@@ -52,7 +52,7 @@ func main() {
 			os.Exit(1)
 		}
 
-		if err := commands.ListEvents(context.Background(), start, end); err != nil {
+		if err := commands.ListEvents(context.Background(), os.Getenv("CALENDAR_IDS"), start, end, os.Getenv("LIMIT")); err != nil {
 			fmt.Println(err)
 			os.Exit(1)
 		}

--- a/microsoft365/outlook/calendar/pkg/client/client.go
+++ b/microsoft365/outlook/calendar/pkg/client/client.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
-	"github.com/obot-platform/tools/microsoft365/outlook/calendar/pkg/global"
 	msgraphsdkgo "github.com/microsoftgraph/msgraph-sdk-go"
+	"github.com/obot-platform/tools/microsoft365/outlook/calendar/pkg/global"
 )
 
 // StaticTokenCredential is taken from https://github.com/gptscript-ai/mail-assistant/blob/10944805801bbb6f71eccefd1bea5f114fded164/pkg/mstoken/auth.go

--- a/microsoft365/outlook/calendar/pkg/commands/listEvents.go
+++ b/microsoft365/outlook/calendar/pkg/commands/listEvents.go
@@ -22,7 +22,6 @@ func ListEvents(ctx context.Context, calendarIDstring string, start, end time.Ti
 	if limit == "" {
 		limitInt = 50 // default limit
 	} else {
-		var err error
 		limitInt64, err := strconv.ParseInt(limit, 10, 32)
 		if err != nil {
 			return fmt.Errorf("invalid limit value provided: (%s) %w. must be a positive integer", limit, err)

--- a/microsoft365/outlook/calendar/pkg/commands/searchEvents.go
+++ b/microsoft365/outlook/calendar/pkg/commands/searchEvents.go
@@ -35,10 +35,11 @@ func SearchEvents(ctx context.Context, query string, start, end time.Time) error
 		return fmt.Errorf("failed to translate calendar IDs: %w", err)
 	}
 
+	limit := int32(100) // default limit for search
 	calendarEventsInSubject := make(map[graph.CalendarInfo][]models.Eventable, len(calendars))
 	calendarEventsInPreview := make(map[graph.CalendarInfo][]models.Eventable, len(calendars))
 	for _, cal := range calendars {
-		result, err := graph.ListCalendarView(ctx, c, cal.ID, cal.Owner, &start, &end)
+		result, err := graph.ListCalendarView(ctx, c, cal.ID, cal.Owner, &start, &end, limit)
 		if err != nil {
 			return fmt.Errorf("failed to search events: %w", err)
 		}

--- a/microsoft365/outlook/calendar/pkg/graph/calendar.go
+++ b/microsoft365/outlook/calendar/pkg/graph/calendar.go
@@ -108,6 +108,7 @@ func ListCalendarView(ctx context.Context, client *msgraphsdkgo.GraphServiceClie
 				EndDateTime:   util.Ptr(util.Deref(end).Format(time.RFC3339)),
 				StartDateTime: util.Ptr(util.Deref(start).Format(time.RFC3339)),
 				Top:           util.Ptr(int32(100)),
+				Orderby:       []string{"start/dateTime"},
 			},
 		})
 
@@ -125,6 +126,7 @@ func ListCalendarView(ctx context.Context, client *msgraphsdkgo.GraphServiceClie
 			EndDateTime:   util.Ptr(util.Deref(end).Format(time.RFC3339)),
 			StartDateTime: util.Ptr(util.Deref(start).Format(time.RFC3339)),
 			Top:           util.Ptr(int32(100)),
+			Orderby:       []string{"start/dateTime"},
 		},
 	})
 

--- a/microsoft365/outlook/calendar/pkg/graph/calendar.go
+++ b/microsoft365/outlook/calendar/pkg/graph/calendar.go
@@ -101,13 +101,13 @@ func ListCalendars(ctx context.Context, client *msgraphsdkgo.GraphServiceClient)
 	return calendars, nil
 }
 
-func ListCalendarView(ctx context.Context, client *msgraphsdkgo.GraphServiceClient, id string, owner OwnerType, start, end *time.Time) ([]models.Eventable, error) {
+func ListCalendarView(ctx context.Context, client *msgraphsdkgo.GraphServiceClient, CalendarId string, owner OwnerType, start, end *time.Time, limit int32) ([]models.Eventable, error) {
 	if owner == OwnerTypeUser {
-		resp, err := client.Me().Calendars().ByCalendarId(id).CalendarView().Get(ctx, &users.ItemCalendarsItemCalendarViewRequestBuilderGetRequestConfiguration{
+		resp, err := client.Me().Calendars().ByCalendarId(CalendarId).CalendarView().Get(ctx, &users.ItemCalendarsItemCalendarViewRequestBuilderGetRequestConfiguration{
 			QueryParameters: &users.ItemCalendarsItemCalendarViewRequestBuilderGetQueryParameters{
 				EndDateTime:   util.Ptr(util.Deref(end).Format(time.RFC3339)),
 				StartDateTime: util.Ptr(util.Deref(start).Format(time.RFC3339)),
-				Top:           util.Ptr(int32(100)),
+				Top:           util.Ptr(limit),
 				Orderby:       []string{"start/dateTime"},
 			},
 		})
@@ -121,11 +121,11 @@ func ListCalendarView(ctx context.Context, client *msgraphsdkgo.GraphServiceClie
 		return resp.GetValue(), nil
 	}
 
-	resp, err := client.Groups().ByGroupId(id).CalendarView().Get(ctx, &groups.ItemCalendarViewRequestBuilderGetRequestConfiguration{
+	resp, err := client.Groups().ByGroupId(CalendarId).CalendarView().Get(ctx, &groups.ItemCalendarViewRequestBuilderGetRequestConfiguration{
 		QueryParameters: &groups.ItemCalendarViewRequestBuilderGetQueryParameters{
 			EndDateTime:   util.Ptr(util.Deref(end).Format(time.RFC3339)),
 			StartDateTime: util.Ptr(util.Deref(start).Format(time.RFC3339)),
-			Top:           util.Ptr(int32(100)),
+			Top:           util.Ptr(limit),
 			Orderby:       []string{"start/dateTime"},
 		},
 	})

--- a/microsoft365/outlook/calendar/pkg/printers/events.go
+++ b/microsoft365/outlook/calendar/pkg/printers/events.go
@@ -3,15 +3,16 @@ package printers
 import (
 	"context"
 	"fmt"
+	"os"
+	"strings"
+	"time"
+	_ "time/tzdata"
+
 	"github.com/jaytaylor/html2text"
 	msgraphsdkgo "github.com/microsoftgraph/msgraph-sdk-go"
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
 	"github.com/obot-platform/tools/microsoft365/outlook/calendar/pkg/graph"
 	"github.com/obot-platform/tools/microsoft365/outlook/calendar/pkg/util"
-	"os"
-	"strings"
-	"time"
-	_ "time/tzdata"
 )
 
 func EventToString(ctx context.Context, client *msgraphsdkgo.GraphServiceClient, calendar graph.CalendarInfo, event models.Eventable) string {

--- a/microsoft365/outlook/calendar/tool.gpt
+++ b/microsoft365/outlook/calendar/tool.gpt
@@ -27,8 +27,10 @@ Description: List all events in the given time frame in all calendars available 
 Share Context: Outlook Calendar Context
 Tools: github.com/gptscript-ai/datasets/filter
 Credential: ../../credential
-Param: start: The start date and time of the time frame, in RFC 3339 format.
-Param: end: The end date and time of the time frame, in RFC 3339 format.
+Param: start: (Required) The start date and time of the time frame, in RFC 3339 format.
+Param: end: (Required) The end date and time of the time frame, in RFC 3339 format.
+Param: calendar_ids: (Optional) A comma-separated list of the unique IDs of the calendars to list events from. If unset, lists events from all calendars.
+Param: limit: (Optional) The maximum number of events to return for each calendar. If unset, returns up to 50 events for each calendar.
 
 #!${GPTSCRIPT_TOOL_DIR}/bin/gptscript-go-tool listEvents
 


### PR DESCRIPTION
- list events order by time: https://github.com/obot-platform/obot/issues/2741
- list events support `calendar_ids` and `limit`. So it doesn't always have to return events from all calendars. https://github.com/obot-platform/obot/issues/2747