### PR TITLE
fix: confirm with user before overwritting existing doc

### DIFF
--- a/microsoft365/word/main.go
+++ b/microsoft365/word/main.go
@@ -28,7 +28,7 @@ func main() {
 	case "getDocByPath":
 		err = commands.GetDocByPath(ctx, os.Getenv("DOC_PATH"))
 	case "writeDoc":
-		err = commands.WriteDoc(ctx, os.Getenv("DOC_NAME"), os.Getenv("DOC_CONTENT"))
+		err = commands.WriteDoc(ctx, os.Getenv("DOC_NAME"), os.Getenv("DOC_CONTENT"), os.Getenv("OVERWRITE_IF_EXISTS") == "true")
 	default:
 		fmt.Printf("Unknown command: %s\n", command)
 		os.Exit(1)

--- a/microsoft365/word/pkg/graph/docs.go
+++ b/microsoft365/word/pkg/graph/docs.go
@@ -359,3 +359,27 @@ func deref[T any](v *T) (r T) {
 	}
 	return
 }
+
+// DocExists checks if a document with the given path exists in the user's OneDrive.
+func DocExists(ctx context.Context, client *msgraphsdkgo.GraphServiceClient, path string) (bool, error) {
+	// Get the user's drive.
+	drive, err := client.Me().Drive().Get(ctx, nil)
+	if err != nil {
+		return false, fmt.Errorf("failed to get drive: %w", err)
+	}
+	driveID := deref(drive.GetId())
+
+	// Try to get the item by path
+	_, err = getItemByPath(ctx, client, driveID, path)
+	if err != nil {
+		if strings.Contains(err.Error(), "item not found") {
+			// Item doesn't exist
+			return false, nil
+		}
+		// Some other error occurred
+		return false, err
+	}
+
+	// Item exists
+	return true, nil
+}

--- a/microsoft365/word/tool.gpt
+++ b/microsoft365/word/tool.gpt
@@ -30,8 +30,9 @@ Name: Write Doc
 Description: Write a Microsoft Word document in OneDrive with the specified title and optional content. The file will be created if it doesn't exist. It will be overwritten if it already exists.
 Share Context: Word Context
 Credential: ../credential
-Param: doc_name: The name of the document to write to. This might be the OneDrive ID of an existing document or a filepath in OneDrive.
-Param: doc_content: Optional markdown formatted content to write to the document.
+Param: doc_name: (Required) The name of the document to write to. This might be the OneDrive ID of an existing document or a filepath in OneDrive.
+Param: doc_content: (Optional) Markdown formatted content to write to the document.
+Param: overwrite_if_exists: (Optional) Whether to overwrite the document if it already exists, defaults to false. You MUST only set this to true if you have confirmed with the user that they want to overwrite the document.
 
 #!${GPTSCRIPT_TOOL_DIR}/bin/gptscript-go-tool writeDoc
 


### PR DESCRIPTION
https://github.com/obot-platform/obot/issues/2673

confirm with the user before overwriting the word doc.