### PR TITLE
Enhance: add ability to fetch user profile

### DIFF
--- a/github-auth-provider/main.go
+++ b/github-auth-provider/main.go
@@ -14,7 +14,6 @@ import (
 	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/apis/options"
 	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/validation"
 	"github.com/obot-platform/tools/auth-providers-common/pkg/env"
-	"github.com/obot-platform/tools/auth-providers-common/pkg/icon"
 	"github.com/obot-platform/tools/auth-providers-common/pkg/state"
 	"github.com/obot-platform/tools/github-auth-provider/pkg/profile"
 )
@@ -133,7 +132,14 @@ func main() {
 		w.Write([]byte(fmt.Sprintf("http://127.0.0.1:%s", port)))
 	})
 	mux.HandleFunc("/obot-get-state", getState(oauthProxy))
-	mux.HandleFunc("/obot-get-icon-url", icon.ObotGetIconURL(profile.FetchGitHubProfileIconURL))
+	mux.HandleFunc("/obot-get-user-info", func(w http.ResponseWriter, r *http.Request) {
+		userInfo, err := profile.FetchGitHubProfile(r.Context(), r.Header.Get("Authorization"))
+		if err != nil {
+			http.Error(w, fmt.Sprintf("failed to fetch user info: %v", err), http.StatusBadRequest)
+			return
+		}
+		json.NewEncoder(w).Encode(userInfo)
+	})
 	mux.HandleFunc("/", oauthProxy.ServeHTTP)
 
 	fmt.Printf("listening on 127.0.0.1:%s\n", port)

--- a/github-auth-provider/pkg/profile/profile.go
+++ b/github-auth-provider/pkg/profile/profile.go
@@ -9,30 +9,61 @@ import (
 )
 
 type githubResponse struct {
-	AvatarURL string `json:"avatar_url"`
+	Login             string `json:"login"`
+	ID                int    `json:"id"`
+	NodeID            string `json:"node_id"`
+	AvatarURL         string `json:"avatar_url"`
+	GravatarID        string `json:"gravatar_id"`
+	URL               string `json:"url"`
+	HTMLURL           string `json:"html_url"`
+	FollowersURL      string `json:"followers_url"`
+	FollowingURL      string `json:"following_url"`
+	GistsURL          string `json:"gists_url"`
+	StarredURL        string `json:"starred_url"`
+	SubscriptionsURL  string `json:"subscriptions_url"`
+	OrganizationsURL  string `json:"organizations_url"`
+	ReposURL          string `json:"repos_url"`
+	EventsURL         string `json:"events_url"`
+	ReceivedEventsURL string `json:"received_events_url"`
+	Type              string `json:"type"`
+	SiteAdmin         bool   `json:"site_admin"`
+	Name              string `json:"name"`
+	Company           string `json:"company"`
+	Blog              string `json:"blog"`
+	Location          string `json:"location"`
+	Email             string `json:"email"`
+	Hireable          bool   `json:"hireable"`
+	Bio               string `json:"bio"`
+	TwitterUsername   string `json:"twitter_username"`
+	PublicRepos       int    `json:"public_repos"`
+	PublicGists       int    `json:"public_gists"`
+	Followers         int    `json:"followers"`
+	Following         int    `json:"following"`
+	CreatedAt         string `json:"created_at"`
+	UpdatedAt         string `json:"updated_at"`
 }
 
-func FetchGitHubProfileIconURL(ctx context.Context, accessToken string) (string, error) {
+func FetchGitHubProfile(ctx context.Context, accessToken string) (*githubResponse, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://api.github.com/user", nil)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
-	req.Header.Set("Authorization", "Bearer "+accessToken)
+	req.Header.Set("Authorization", accessToken)
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		result, _ := io.ReadAll(resp.Body)
-		return "", fmt.Errorf("unexpected status code: %d: %s", resp.StatusCode, result)
+		return nil, fmt.Errorf("unexpected status code: %d: %s", resp.StatusCode, result)
 	}
 
 	var profile githubResponse
 	if err = json.NewDecoder(resp.Body).Decode(&profile); err != nil {
-		return "", err
+		return nil, err
 	}
 
-	return profile.AvatarURL, nil
+	return &profile, nil
 }

--- a/google-auth-provider/main.go
+++ b/google-auth-provider/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -14,7 +15,6 @@ import (
 	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/apis/options"
 	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/validation"
 	"github.com/obot-platform/tools/auth-providers-common/pkg/env"
-	"github.com/obot-platform/tools/auth-providers-common/pkg/icon"
 	"github.com/obot-platform/tools/auth-providers-common/pkg/state"
 	"github.com/obot-platform/tools/google-auth-provider/pkg/profile"
 )
@@ -111,7 +111,15 @@ func main() {
 		w.Write([]byte(fmt.Sprintf("http://127.0.0.1:%s", port)))
 	})
 	mux.HandleFunc("/obot-get-state", state.ObotGetState(oauthProxy))
-	mux.HandleFunc("/obot-get-icon-url", icon.ObotGetIconURL(profile.FetchGoogleProfileIconURL))
+	mux.HandleFunc("/obot-get-user-info", func(w http.ResponseWriter, r *http.Request) {
+		userInfo, err := profile.FetchGoogleProfile(r.Context(), r.Header.Get("Authorization"))
+		if err != nil {
+			http.Error(w, fmt.Sprintf("failed to fetch user info: %v", err), http.StatusBadRequest)
+			return
+		}
+
+		json.NewEncoder(w).Encode(userInfo)
+	})
 	mux.HandleFunc("/", oauthProxy.ServeHTTP)
 
 	fmt.Printf("listening on 127.0.0.1:%s\n", port)

--- a/google-auth-provider/pkg/profile/profile.go
+++ b/google-auth-provider/pkg/profile/profile.go
@@ -19,27 +19,27 @@ type googleProfile struct {
 	HD            string `json:"hd"`
 }
 
-func FetchGoogleProfileIconURL(ctx context.Context, accessToken string) (string, error) {
+func FetchGoogleProfile(ctx context.Context, accessToken string) (*googleProfile, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://openidconnect.googleapis.com/v1/userinfo", nil)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
-	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", accessToken))
+	req.Header.Set("Authorization", accessToken)
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		result, _ := io.ReadAll(resp.Body)
-		return "", fmt.Errorf("unexpected status code: %d: %s", resp.StatusCode, result)
+		return nil, fmt.Errorf("unexpected status code: %d: %s", resp.StatusCode, result)
 	}
 
 	var profile googleProfile
 	if err = json.NewDecoder(resp.Body).Decode(&profile); err != nil {
-		return "", err
+		return nil, err
 	}
 
-	return profile.Picture, nil
+	return &profile, nil
 }


### PR DESCRIPTION
Add a different endpoint to fetch user profile from auth provider. It can be used to supply friendly username/icon url from auth provider.