### PR TITLE
fix: cred helpers: don't attempt to parse 'unused' as a list of contexts

### DIFF
--- a/credential-stores/postgres/main.go
+++ b/credential-stores/postgres/main.go
@@ -50,7 +50,7 @@ func main() {
 	mux.HandleFunc("POST /list", authenticatedHandler(func(w http.ResponseWriter, r *http.Request) {
 		// Check for context in the body.
 		body, err := io.ReadAll(r.Body)
-		if err == nil && len(body) > 0 {
+		if err == nil && len(body) > 0 && string(body) != "unused" {
 			var contexts []string
 			if err := json.Unmarshal(body, &contexts); err != nil {
 				http.Error(w, "invalid request body: body must be a JSON array of credential context strings", http.StatusBadRequest)

--- a/credential-stores/sqlite/main.go
+++ b/credential-stores/sqlite/main.go
@@ -51,7 +51,7 @@ func main() {
 	mux.HandleFunc("POST /list", authenticatedHandler(func(w http.ResponseWriter, r *http.Request) {
 		// Check for context in the body.
 		body, err := io.ReadAll(r.Body)
-		if err == nil && len(body) > 0 {
+		if err == nil && len(body) > 0 && string(body) != "unused" {
 			var contexts []string
 			if err := json.Unmarshal(body, &contexts); err != nil {
 				http.Error(w, "invalid request body: body must be a JSON array of credential context strings", http.StatusBadRequest)


### PR DESCRIPTION
Apparently Docker's libraries fill in the body with `unused` if it's unused, which was leading to an error here that we don't want.