### PR TITLE
enhance: expose github auth group data

### DIFF
--- a/auth-providers-common/pkg/state/state.go
+++ b/auth-providers-common/pkg/state/state.go
@@ -9,6 +9,22 @@ import (
 	oauth2proxy "github.com/oauth2-proxy/oauth2-proxy/v7"
 )
 
+type GroupInfo struct {
+	ID      string  `json:"id"`
+	Name    string  `json:"name"`
+	IconURL *string `json:"iconURL,omitempty"`
+}
+
+type GroupInfoList []GroupInfo
+
+func (a GroupInfoList) IDs() []string {
+	ids := make([]string, len(a))
+	for i, group := range a {
+		ids[i] = group.ID
+	}
+	return ids
+}
+
 type SerializableRequest struct {
 	Method string              `json:"method"`
 	URL    string              `json:"url"`
@@ -16,12 +32,14 @@ type SerializableRequest struct {
 }
 
 type SerializableState struct {
-	ExpiresOn         *time.Time `json:"expiresOn"`
-	AccessToken       string     `json:"accessToken"`
-	PreferredUsername string     `json:"preferredUsername"`
-	User              string     `json:"user"`
-	Email             string     `json:"email"`
-	SetCookies        []string   `json:"setCookies"`
+	ExpiresOn         *time.Time    `json:"expiresOn"`
+	AccessToken       string        `json:"accessToken"`
+	PreferredUsername string        `json:"preferredUsername"`
+	User              string        `json:"user"`
+	Email             string        `json:"email"`
+	Groups            []string      `json:"groups"`
+	GroupInfos        GroupInfoList `json:"groupInfos"`
+	SetCookies        []string      `json:"setCookies"`
 }
 
 func ObotGetState(p *oauth2proxy.OAuthProxy) http.HandlerFunc {
@@ -77,6 +95,8 @@ func GetSerializableState(p *oauth2proxy.OAuthProxy, r *http.Request) (Serializa
 		PreferredUsername: state.PreferredUsername,
 		User:              state.User,
 		Email:             state.Email,
+		Groups:            state.Groups,
+		GroupInfos:        GroupInfoList{},
 		SetCookies:        setCookies,
 	}, nil
 }

--- a/github-auth-provider/Makefile
+++ b/github-auth-provider/Makefile
@@ -1,0 +1,2 @@
+build:
+	go build -o bin/gptscript-go-tool .

--- a/github-auth-provider/go.mod
+++ b/github-auth-provider/go.mod
@@ -62,6 +62,7 @@ require (
 	github.com/redis/go-redis/v9 v9.7.3 // indirect
 	github.com/sagikazarmark/locafero v0.7.0 // indirect
 	github.com/sagikazarmark/slog-shim v0.1.0 // indirect
+	github.com/sahilm/fuzzy v0.1.1 // indirect
 	github.com/sourcegraph/conc v0.3.0 // indirect
 	github.com/spf13/afero v1.12.0 // indirect
 	github.com/spf13/cast v1.7.1 // indirect

--- a/github-auth-provider/go.sum
+++ b/github-auth-provider/go.sum
@@ -139,6 +139,8 @@ github.com/sagikazarmark/locafero v0.7.0 h1:5MqpDsTGNDhY8sGp0Aowyf0qKsPrhewaLSsF
 github.com/sagikazarmark/locafero v0.7.0/go.mod h1:2za3Cg5rMaTMoG/2Ulr9AwtFaIppKXTRYnozin4aB5k=
 github.com/sagikazarmark/slog-shim v0.1.0 h1:diDBnUNK9N/354PgrxMywXnAwEr1QZcOr6gto+ugjYE=
 github.com/sagikazarmark/slog-shim v0.1.0/go.mod h1:SrcSrq8aKtyuqEI1uvTDTK1arOWRIczQRv+GVI1AkeQ=
+github.com/sahilm/fuzzy v0.1.1 h1:ceu5RHF8DGgoi+/dR5PsECjCDH1BE3Fnmpo7aVXOdRA=
+github.com/sahilm/fuzzy v0.1.1/go.mod h1:VFvziUEIMCrT6A6tw2RFIXPXXmzXbOsSHF0DOI8ZK9Y=
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=
 github.com/sourcegraph/conc v0.3.0/go.mod h1:Sdozi7LEKbFPqYX2/J+iBAM6HpqSLTASQIKqDmF7Mt0=
 github.com/spf13/afero v1.12.0 h1:UcOPyRBYczmFn6yvphxkn9ZEOY65cpwGKb5mL36mrqs=

--- a/github-auth-provider/pkg/profile/profile_test.go
+++ b/github-auth-provider/pkg/profile/profile_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestFetchGitHubProfile(t *testing.T) {
 	// Arrange: setup a mock server
-	mockResponse := githubResponse{
+	mockResponse := githubUserProfile{
 		Login:     "mockuser",
 		AvatarURL: "https://example.com/avatar.png",
 		Name:      "Mock User",
@@ -32,8 +32,9 @@ func TestFetchGitHubProfile(t *testing.T) {
 	defer server.Close()
 
 	// Act: call the function with mock server URL
+	githubBaseURL = server.URL
 	ctx := context.Background()
-	profile, err := FetchGitHubProfile(ctx, "Bearer mocktoken", server.URL)
+	profile, err := FetchUserProfile(ctx, "Bearer mocktoken")
 
 	// Assert: check no error
 	if err != nil {


### PR DESCRIPTION
- Add the `/obot-list-auth-group` endpoint to the github auth provider
  to support searching for a user's org/teams
- Enrich `/obot-get-state` response to include orgs/teams data
