### PR TITLE
enhance: use provider wrappers to enrich github auth info

### DIFF
--- a/github-auth-provider/go.mod
+++ b/github-auth-provider/go.mod
@@ -5,13 +5,14 @@ go 1.23.7
 toolchain go1.24.1
 
 replace (
-	github.com/oauth2-proxy/oauth2-proxy/v7 => github.com/obot-platform/oauth2-proxy/v7 v7.0.0-20250402151943-8bfeb682f4c4
+	github.com/oauth2-proxy/oauth2-proxy/v7 => github.com/njhale/oauth2-proxy/v7 v7.0.0-20250723153722-76f81f01882a
 	github.com/obot-platform/tools/auth-providers-common => ../auth-providers-common
 )
 
 require (
 	github.com/oauth2-proxy/oauth2-proxy/v7 v7.8.1
 	github.com/obot-platform/tools/auth-providers-common v0.0.0-20241008222508-3c6174b443e7
+	github.com/sahilm/fuzzy v0.1.1
 )
 
 require (
@@ -62,7 +63,6 @@ require (
 	github.com/redis/go-redis/v9 v9.7.3 // indirect
 	github.com/sagikazarmark/locafero v0.7.0 // indirect
 	github.com/sagikazarmark/slog-shim v0.1.0 // indirect
-	github.com/sahilm/fuzzy v0.1.1 // indirect
 	github.com/sourcegraph/conc v0.3.0 // indirect
 	github.com/spf13/afero v1.12.0 // indirect
 	github.com/spf13/cast v1.7.1 // indirect

--- a/github-auth-provider/go.sum
+++ b/github-auth-provider/go.sum
@@ -108,10 +108,10 @@ github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyua
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
+github.com/njhale/oauth2-proxy/v7 v7.0.0-20250723153722-76f81f01882a h1:0XHduJN7sLCORZCow8OIdPnNVRL86FrTF+Q2R0x76P4=
+github.com/njhale/oauth2-proxy/v7 v7.0.0-20250723153722-76f81f01882a/go.mod h1:BlSghhlE4b+Xwhp2EPfsUV1CPb1w2JtDtqBoA8D8pBw=
 github.com/oauth2-proxy/mockoidc v0.0.0-20240214162133-caebfff84d25 h1:9bCMuD3TcnjeqjPT2gSlha4asp8NvgcFRYExCaikCxk=
 github.com/oauth2-proxy/mockoidc v0.0.0-20240214162133-caebfff84d25/go.mod h1:eDjgYHYDJbPLBLsyZ6qRaugP0mX8vePOhZ5id1fdzJw=
-github.com/obot-platform/oauth2-proxy/v7 v7.0.0-20250402151943-8bfeb682f4c4 h1:P25630HNYdk42f9LrTpcxOM1J8xMTW2idxTuV2lWBLw=
-github.com/obot-platform/oauth2-proxy/v7 v7.0.0-20250402151943-8bfeb682f4c4/go.mod h1:BlSghhlE4b+Xwhp2EPfsUV1CPb1w2JtDtqBoA8D8pBw=
 github.com/onsi/ginkgo/v2 v2.23.3 h1:edHxnszytJ4lD9D5Jjc4tiDkPBZ3siDeJJkUZJJVkp0=
 github.com/onsi/ginkgo/v2 v2.23.3/go.mod h1:zXTP6xIp3U8aVuXN8ENK9IXRaTjFnpVB9mGmaSRvxnM=
 github.com/onsi/gomega v1.36.3 h1:hID7cr8t3Wp26+cYnfcjR6HpJ00fdogN6dqZ1t6IylU=

--- a/github-auth-provider/pkg/profile/profile.go
+++ b/github-auth-provider/pkg/profile/profile.go
@@ -71,15 +71,16 @@ func FetchUserProfile(ctx context.Context, accessToken string) (*githubUserProfi
 }
 
 func FetchUserGroupInfos(ctx context.Context, accessToken string) (state.GroupInfoList, error) {
-	var infos state.GroupInfoList
-
-	var orgs []githubOrganization
+	var (
+		groupsInfos state.GroupInfoList
+		orgs        []githubOrganization
+	)
 	err := makeGitHubRequest(ctx, accessToken, "user/orgs", &orgs)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch user organizations: %w", err)
 	}
 	for _, org := range orgs {
-		infos = append(infos, state.GroupInfo{
+		groupsInfos = append(groupsInfos, state.GroupInfo{
 			ID:      fmt.Sprintf("github/org/%d", org.ID),
 			Name:    org.Login,
 			IconURL: &org.AvatarURL,
@@ -92,7 +93,7 @@ func FetchUserGroupInfos(ctx context.Context, accessToken string) (state.GroupIn
 		return nil, fmt.Errorf("failed to fetch user teams: %w", err)
 	}
 	for _, team := range teams {
-		infos = append(infos, state.GroupInfo{
+		groupsInfos = append(groupsInfos, state.GroupInfo{
 			ID:      fmt.Sprintf("github/org/%d/team/%d", team.Organization.ID, team.ID),
 			Name:    team.Name,
 			IconURL: &team.Organization.AvatarURL,
@@ -100,11 +101,11 @@ func FetchUserGroupInfos(ctx context.Context, accessToken string) (state.GroupIn
 	}
 
 	// Sort groups by ID lexicographically
-	slices.SortFunc(infos, func(a, b state.GroupInfo) int {
+	slices.SortFunc(groupsInfos, func(a, b state.GroupInfo) int {
 		return strings.Compare(a.ID, b.ID)
 	})
 
-	return infos, nil
+	return groupsInfos, nil
 }
 
 func makeGitHubRequest(ctx context.Context, accessToken, path string, result any) error {


### PR DESCRIPTION
Instead of making querying GitHub every time `/obot-get-state` is
called, use a "provider wrapper" to inject custom session enrichment
logic. This greatly reduces the number of requests made to GitHub and
ensures the corrected info is stored in the session (cookie/postgres) by
the oauth proxy after initial authentication.

Part of https://github.com/obot-platform/obot/issues/3484

Signed-off-by: Nick Hale <4175918+njhale@users.noreply.github.com>
