### PR TITLE
chore: remove project scope options from workspace-files

### DIFF
--- a/workspace-files/main.go
+++ b/workspace-files/main.go
@@ -208,26 +208,19 @@ func list(ctx context.Context, filename string) error {
 
 	// Output with XML-like tags using string builder
 	var output strings.Builder
-	output.WriteString("<files_in_workspace>\n")
 	if len(toPrint) > 0 {
-		output.WriteString("List of files currently in workspace:\n")
+		output.WriteString("<files_in_workspace>\n")
+		output.WriteString("List of files currently in thread workspace:\n")
 		output.WriteString(strings.Join(slices.Sorted(maps.Keys(toPrint)), "\n"))
-		output.WriteString("\n")
-	} else {
-		output.WriteString("No files found in workspace\n")
+		output.WriteString("\n</files_in_workspace>\n")
 	}
-	output.WriteString("</files_in_workspace>\n\n")
 
-	output.WriteString("<files_in_project_workspace>\n")
 	if len(projectToPrint) > 0 {
+		output.WriteString("<files_in_project_workspace>\n")
 		output.WriteString("List of files currently in project workspace:\n")
 		output.WriteString(strings.Join(slices.Sorted(maps.Keys(projectToPrint)), "\n"))
-		output.WriteString("\n")
-	} else {
-		output.WriteString("No files found in project workspace\n")
+		output.WriteString("\n</files_in_project_workspace>\n")
 	}
-	output.WriteString("</files_in_project_workspace>\n")
-
 	fmt.Print(output.String())
 
 	return nil

--- a/workspace-files/tool.gpt
+++ b/workspace-files/tool.gpt
@@ -60,7 +60,6 @@ Params: dir: The directory to list files from
 Name: workspace_read
 Description: Read the contents of a file in the workspace. For non-plain text files, it will parse the text. If the text is too long, it will summarize the text.
 Credential: sys.model.provider.credential
-Params: project_scoped: Whether to read the file from the project workspace (default is false)
 Params: filename: The filename to read
 
 #!${GPTSCRIPT_TOOL_DIR}/bin/gptscript-go-tool read
@@ -68,7 +67,6 @@ Params: filename: The filename to read
 ---
 Name: workspace_file_download_url
 Description: Get a URL that the current user can use to download a given workspace file. This URL is authenticated and authorized to the current user and is not appropriate for public sharing.
-Params: project_scoped: Whether the file is in the project workspace (default is false)
 Params: filename: The filename to get a download URL for
 
 #!${GPTSCRIPT_TOOL_DIR}/bin/gptscript-go-tool download-url
@@ -76,7 +74,6 @@ Params: filename: The filename to get a download URL for
 ---
 Name: workspace_write
 Description: Writes content to a file, replacing any existing content if the file already exists. Supports only plain text formats (e.g., .txt, .md).
-Params: project_scoped: Whether to write the file in the project workspace (default is false)
 Params: filename: The filename to write to
 Params: content: The contents to write to the file
 
@@ -85,7 +82,6 @@ Params: content: The contents to write to the file
 ---
 Name: workspace_copy
 Description: Copy the contents of a file to a new filename
-Params: project_scoped: Whether the file is in the project workspace (default is false)
 Params: filename: The filename to copy from
 Params: to_filename: The new filename to copy to
 


### PR DESCRIPTION
Remove project scope parameters and context from workspace-files tools.
This will prevent the LLM from accidentally writing to/reading from the
project workspace. Leave the core project-scoped login in case we decide
to revive the feature down the road.

Addresses https://github.com/obot-platform/obot/issues/3555
