### PR TITLE
chore: update groq logo url

### DIFF
--- a/groq-model-provider/tool.gpt
+++ b/groq-model-provider/tool.gpt
@@ -9,7 +9,7 @@ Metadata: noUserAuth: groq-model-provider
 ---
 !metadata:Groq:providerMeta
 {
-    "icon": "https://www.groq.com/logo.svg",
+    "icon": "https://upload.wikimedia.org/wikipedia/commons/c/cc/Groq_logo.svg",
     "link": "https://groq.com/",
     "envVars": [
         {


### PR DESCRIPTION
We will eventually package this logo as an asset in Obot, but for now, update the groq-model-provider to use a working logo URL.
