### PR TITLE
enhance: fully qualify github team names by org login

### DIFF
--- a/github-auth-provider/pkg/profile/profile.go
+++ b/github-auth-provider/pkg/profile/profile.go
@@ -57,7 +57,7 @@ type githubOrganization struct {
 
 type githubTeam struct {
 	ID           int64              `json:"id"`
-	Name         string             `json:"name"`
+	Slug         string             `json:"slug"`
 	Organization githubOrganization `json:"organization"`
 }
 
@@ -94,7 +94,7 @@ func FetchUserGroupInfos(ctx context.Context, accessToken string) (state.GroupIn
 	for _, team := range teams {
 		infos = append(infos, state.GroupInfo{
 			ID:      fmt.Sprintf("github/org/%d/team/%d", team.Organization.ID, team.ID),
-			Name:    team.Name,
+			Name:    fmt.Sprintf("%s/%s", team.Organization.Login, team.Slug),
 			IconURL: &team.Organization.AvatarURL,
 		})
 	}


### PR DESCRIPTION
Change GitHub team display names to use `<org-login>/<team-slug>`.
Before we were using the team display names from GitHub, which are both
not unique and make it hard to differentiate between orgs and teams in
the Obot UI.

Addresses https://github.com/obot-platform/obot/issues/4012

Depends on https://github.com/obot-platform/obot/pull/4034

Loom https://www.loom.com/share/c1bcd24b5b284ed391871dba56e74d43?sid=b4d72780-20b5-4cd2-9f2d-a80943fc1cab
