### PR TITLE
enhance: add validate tool for github auth provider

### DIFF
--- a/github-auth-provider/go.mod
+++ b/github-auth-provider/go.mod
@@ -12,6 +12,8 @@ replace (
 require (
 	github.com/oauth2-proxy/oauth2-proxy/v7 v7.8.1
 	github.com/obot-platform/tools/auth-providers-common v0.0.0-20241008222508-3c6174b443e7
+	github.com/sahilm/fuzzy v0.1.1
+	github.com/stretchr/testify v1.10.0
 )
 
 require (
@@ -26,6 +28,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/coreos/go-oidc/v3 v3.13.0 // indirect
 	github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf // indirect
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fsnotify/fsnotify v1.8.0 // indirect
@@ -55,6 +58,7 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.3 // indirect
 	github.com/pierrec/lz4/v4 v4.1.22 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_golang v1.21.1 // indirect
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.62.0 // indirect
@@ -62,7 +66,6 @@ require (
 	github.com/redis/go-redis/v9 v9.7.3 // indirect
 	github.com/sagikazarmark/locafero v0.7.0 // indirect
 	github.com/sagikazarmark/slog-shim v0.1.0 // indirect
-	github.com/sahilm/fuzzy v0.1.1 // indirect
 	github.com/sourcegraph/conc v0.3.0 // indirect
 	github.com/spf13/afero v1.12.0 // indirect
 	github.com/spf13/cast v1.7.1 // indirect

--- a/github-auth-provider/pkg/config/config.go
+++ b/github-auth-provider/pkg/config/config.go
@@ -1,0 +1,176 @@
+package config
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/obot-platform/tools/auth-providers-common/pkg/env"
+)
+
+// options is the private struct that holds raw environment variable values
+type options struct {
+	ClientID                 string  `env:"OBOT_GITHUB_AUTH_PROVIDER_CLIENT_ID"`
+	ClientSecret             string  `env:"OBOT_GITHUB_AUTH_PROVIDER_CLIENT_SECRET"`
+	ObotServerURL            string  `env:"OBOT_SERVER_URL"`
+	PostgresConnectionDSN    string  `env:"OBOT_AUTH_PROVIDER_POSTGRES_CONNECTION_DSN" optional:"true"`
+	AuthCookieSecret         string  `usage:"Secret used to encrypt cookie" env:"OBOT_AUTH_PROVIDER_COOKIE_SECRET"`
+	AuthEmailDomains         string  `usage:"Email domains allowed for authentication" default:"*" env:"OBOT_AUTH_PROVIDER_EMAIL_DOMAINS"`
+	AuthTokenRefreshDuration string  `usage:"Duration to refresh auth token after" optional:"true" default:"1h" env:"OBOT_AUTH_PROVIDER_TOKEN_REFRESH_DURATION"`
+	GitHubOrg                *string `usage:"restrict logins to members of this GitHub organization" optional:"true" env:"OBOT_GITHUB_AUTH_PROVIDER_ORG"`
+	GitHubAllowUsers         *string `usage:"users allowed to log in, even if they do not belong to the specified org and team or collaborators" optional:"true" env:"OBOT_GITHUB_AUTH_PROVIDER_ALLOW_USERS"`
+}
+
+// Options is the public struct that holds validated and processed configuration values
+type Options struct {
+	options
+	AuthEmailDomains         []string
+	AuthTokenRefreshDuration time.Duration
+	GitHubOrg                string
+	GitHubAllowUsers         []string
+}
+
+var (
+	gitHubLoginRegex = regexp.MustCompile(`^[a-zA-Z0-9]+(-[a-zA-Z0-9]+)*$`)
+	emailDomainRegex = regexp.MustCompile(`^[a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?)*$`)
+)
+
+// LoadEnv loads environment variables, validates them, and returns the completed configuration
+func LoadEnv() (*Options, error) {
+	completed, err := loadEnv()
+	if err != nil {
+		return nil, env.ValidationError{Err: err}
+	}
+
+	return completed, nil
+}
+
+func loadEnv() (*Options, error) {
+	var opts options
+	if err := env.LoadEnvForStruct(&opts); err != nil {
+		return nil, fmt.Errorf("failed to load environment variables: %w", err)
+	}
+
+	return complete(opts)
+}
+
+func complete(o options) (*Options, error) {
+	var (
+		validationErrors env.FieldValidationErrors
+		completedOptions = Options{
+			options: o,
+		}
+	)
+
+	if o.AuthEmailDomains != "" {
+		// TODO(njhale): Add validation for email domains
+		var (
+			emailDomains = strings.Split(o.AuthEmailDomains, ",")
+			errorMsg     string
+		)
+		for i := range emailDomains {
+			switch domain := strings.TrimSpace(emailDomains[i]); {
+			case domain == "":
+				errorMsg = "cannot contain empty email domains"
+			case domain == "*" && len(emailDomains) > 1:
+				errorMsg = "cannot specify multiple email domains when * is provided"
+			case domain != "*" && !emailDomainRegex.MatchString(domain):
+				errorMsg = fmt.Sprintf("'%s' is not a valid email domain", domain)
+			default:
+				emailDomains[i] = domain
+				continue
+			}
+
+			// Stop after the first email domain validation error
+			break
+		}
+
+		if errorMsg != "" {
+			validationErrors = append(validationErrors, env.FieldValidationError{
+				EnvVar:    "OBOT_AUTH_PROVIDER_EMAIL_DOMAINS",
+				Message:   errorMsg,
+				Value:     o.AuthEmailDomains,
+				Sensitive: false,
+			})
+		} else {
+			completedOptions.AuthEmailDomains = emailDomains
+		}
+
+	}
+
+	refreshDuration, err := time.ParseDuration(o.AuthTokenRefreshDuration)
+	if err != nil || refreshDuration <= 0 {
+		validationErrors = append(validationErrors, env.FieldValidationError{
+			EnvVar:    "OBOT_AUTH_PROVIDER_TOKEN_REFRESH_DURATION",
+			Message:   "must be a valid duration string and greater than 0",
+			Value:     o.AuthTokenRefreshDuration,
+			Sensitive: false,
+		})
+	} else {
+		completedOptions.AuthTokenRefreshDuration = refreshDuration
+	}
+
+	if o.GitHubOrg != nil && *o.GitHubOrg != "" {
+		var (
+			org      = *o.GitHubOrg
+			errorMsg string
+		)
+		if len(org) > 39 {
+			errorMsg = fmt.Sprintf("must be 39 characters or less, got %d characters", len(org))
+		}
+		if !gitHubLoginRegex.MatchString(org) {
+			errorMsg = "is not a valid GitHub organization login (must contain only alphanumeric characters and single hyphens, cannot start or end with hyphen)"
+		}
+		if errorMsg != "" {
+			validationErrors = append(validationErrors, env.FieldValidationError{
+				EnvVar:    "OBOT_GITHUB_AUTH_PROVIDER_ORG",
+				Message:   errorMsg,
+				Value:     org,
+				Sensitive: false,
+			})
+		} else {
+			completedOptions.GitHubOrg = org
+		}
+	}
+
+	if o.GitHubAllowUsers != nil && *o.GitHubAllowUsers != "" {
+		var (
+			users    = strings.Split(*o.GitHubAllowUsers, ",")
+			errorMsg string
+		)
+		for i := range users {
+			switch user := strings.TrimSpace(users[i]); {
+			case user == "":
+				errorMsg = "cannot contain empty users"
+			case len(user) > 39:
+				errorMsg = fmt.Sprintf("user '%s' must be 39 characters or less, got %d characters", user, len(user))
+			case !gitHubLoginRegex.MatchString(user):
+				errorMsg = fmt.Sprintf("user '%s' is not a valid GitHub username (must contain only alphanumeric characters and single hyphens, cannot start or end with hyphen)", user)
+			default:
+				users[i] = user
+				continue
+			}
+
+			// Stop after the first user validation error
+			break
+		}
+
+		if errorMsg != "" {
+			validationErrors = append(validationErrors, env.FieldValidationError{
+				EnvVar:    "OBOT_GITHUB_AUTH_PROVIDER_ALLOW_USERS",
+				Message:   errorMsg,
+				Value:     *o.GitHubAllowUsers,
+				Sensitive: false,
+			})
+		} else {
+			completedOptions.GitHubAllowUsers = users
+		}
+	}
+
+	if len(validationErrors) > 0 {
+		return nil, validationErrors
+	}
+
+	return &completedOptions, nil
+}

--- a/github-auth-provider/pkg/config/config_test.go
+++ b/github-auth-provider/pkg/config/config_test.go
@@ -1,0 +1,533 @@
+package config
+
+import (
+	"testing"
+	"time"
+
+	"github.com/obot-platform/tools/auth-providers-common/pkg/env"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestComplete(t *testing.T) {
+	type expected struct {
+		completed *Options
+		err       error
+	}
+
+	tests := []struct {
+		name     string
+		input    options
+		expected expected
+	}{
+		{
+			name: "valid configuration with all fields",
+			input: options{
+				ClientID:                 "client123",
+				ClientSecret:             "secret456",
+				ObotServerURL:            "https://example.com",
+				AuthCookieSecret:         "cookiesecret",
+				AuthEmailDomains:         "example.com,test.org",
+				AuthTokenRefreshDuration: "2h",
+				GitHubOrg:                ptr("myorg"),
+				GitHubAllowUsers:         ptr("user1,user2"),
+			},
+			expected: expected{
+				completed: &Options{
+					options: options{
+						ClientID:                 "client123",
+						ClientSecret:             "secret456",
+						ObotServerURL:            "https://example.com",
+						AuthCookieSecret:         "cookiesecret",
+						AuthEmailDomains:         "example.com,test.org",
+						AuthTokenRefreshDuration: "2h",
+						GitHubOrg:                ptr("myorg"),
+						GitHubAllowUsers:         ptr("user1,user2"),
+					},
+					AuthEmailDomains:         []string{"example.com", "test.org"},
+					AuthTokenRefreshDuration: 2 * time.Hour,
+					GitHubOrg:                "myorg",
+					GitHubAllowUsers:         []string{"user1", "user2"},
+				},
+			},
+		},
+		{
+			name: "minimal valid configuration",
+			input: options{
+				ClientID:                 "client123",
+				ClientSecret:             "secret456",
+				ObotServerURL:            "https://example.com",
+				AuthCookieSecret:         "cookiesecret",
+				AuthEmailDomains:         "*",
+				AuthTokenRefreshDuration: "1h",
+			},
+			expected: expected{
+				completed: &Options{
+					options: options{
+						ClientID:                 "client123",
+						ClientSecret:             "secret456",
+						ObotServerURL:            "https://example.com",
+						AuthCookieSecret:         "cookiesecret",
+						AuthEmailDomains:         "*",
+						AuthTokenRefreshDuration: "1h",
+					},
+					AuthEmailDomains:         []string{"*"},
+					AuthTokenRefreshDuration: 1 * time.Hour,
+				},
+			},
+		},
+		{
+			name: "empty email domains",
+			input: options{
+				ClientID:                 "client123",
+				ClientSecret:             "secret456",
+				ObotServerURL:            "https://example.com",
+				AuthCookieSecret:         "cookiesecret",
+				AuthEmailDomains:         "example.com,,test.org",
+				AuthTokenRefreshDuration: "1h",
+			},
+			expected: expected{
+				err: env.FieldValidationError{
+					EnvVar:  "OBOT_AUTH_PROVIDER_EMAIL_DOMAINS",
+					Message: "cannot contain empty email domains",
+					Value:   "example.com,,test.org",
+				},
+			},
+		},
+		{
+			name: "wildcard with other domains",
+			input: options{
+				ClientID:                 "client123",
+				ClientSecret:             "secret456",
+				ObotServerURL:            "https://example.com",
+				AuthCookieSecret:         "cookiesecret",
+				AuthEmailDomains:         "*,example.com",
+				AuthTokenRefreshDuration: "1h",
+			},
+			expected: expected{
+				err: env.FieldValidationError{
+					EnvVar:  "OBOT_AUTH_PROVIDER_EMAIL_DOMAINS",
+					Message: "cannot specify multiple email domains when * is provided",
+					Value:   "*,example.com",
+				},
+			},
+		},
+		{
+			name: "invalid email domain",
+			input: options{
+				ClientID:                 "client123",
+				ClientSecret:             "secret456",
+				ObotServerURL:            "https://example.com",
+				AuthCookieSecret:         "cookiesecret",
+				AuthEmailDomains:         "invalid..domain",
+				AuthTokenRefreshDuration: "1h",
+			},
+			expected: expected{
+				err: env.FieldValidationError{
+					EnvVar:  "OBOT_AUTH_PROVIDER_EMAIL_DOMAINS",
+					Message: "'invalid..domain' is not a valid email domain",
+					Value:   "invalid..domain",
+				},
+			},
+		},
+		{
+			name: "invalid duration",
+			input: options{
+				ClientID:                 "client123",
+				ClientSecret:             "secret456",
+				ObotServerURL:            "https://example.com",
+				AuthCookieSecret:         "cookiesecret",
+				AuthEmailDomains:         "*",
+				AuthTokenRefreshDuration: "invalid",
+			},
+			expected: expected{
+				err: env.FieldValidationError{
+					EnvVar:  "OBOT_AUTH_PROVIDER_TOKEN_REFRESH_DURATION",
+					Message: "must be a valid duration string and greater than 0",
+					Value:   "invalid",
+				},
+			},
+		},
+		{
+			name: "zero duration",
+			input: options{
+				ClientID:                 "client123",
+				ClientSecret:             "secret456",
+				ObotServerURL:            "https://example.com",
+				AuthCookieSecret:         "cookiesecret",
+				AuthEmailDomains:         "*",
+				AuthTokenRefreshDuration: "0s",
+			},
+			expected: expected{
+				err: env.FieldValidationError{
+					EnvVar:  "OBOT_AUTH_PROVIDER_TOKEN_REFRESH_DURATION",
+					Message: "must be a valid duration string and greater than 0",
+					Value:   "0s",
+				},
+			},
+		},
+		{
+			name: "negative duration",
+			input: options{
+				ClientID:                 "client123",
+				ClientSecret:             "secret456",
+				ObotServerURL:            "https://example.com",
+				AuthCookieSecret:         "cookiesecret",
+				AuthEmailDomains:         "*",
+				AuthTokenRefreshDuration: "-1h",
+			},
+			expected: expected{
+				err: env.FieldValidationError{
+					EnvVar:  "OBOT_AUTH_PROVIDER_TOKEN_REFRESH_DURATION",
+					Message: "must be a valid duration string and greater than 0",
+					Value:   "-1h",
+				},
+			},
+		},
+		{
+			name: "very short valid duration",
+			input: options{
+				ClientID:                 "client123",
+				ClientSecret:             "secret456",
+				ObotServerURL:            "https://example.com",
+				AuthCookieSecret:         "cookiesecret",
+				AuthEmailDomains:         "*",
+				AuthTokenRefreshDuration: "1ns",
+			},
+			expected: expected{
+				completed: &Options{
+					options: options{
+						ClientID:                 "client123",
+						ClientSecret:             "secret456",
+						ObotServerURL:            "https://example.com",
+						AuthCookieSecret:         "cookiesecret",
+						AuthEmailDomains:         "*",
+						AuthTokenRefreshDuration: "1ns",
+					},
+					AuthEmailDomains:         []string{"*"},
+					AuthTokenRefreshDuration: 1 * time.Nanosecond,
+				},
+			},
+		},
+		{
+			name: "GitHub org too long",
+			input: options{
+				ClientID:                 "client123",
+				ClientSecret:             "secret456",
+				ObotServerURL:            "https://example.com",
+				AuthCookieSecret:         "cookiesecret",
+				AuthEmailDomains:         "*",
+				AuthTokenRefreshDuration: "1h",
+				GitHubOrg:                ptr("this-organization-name-is-way-too-long-to-be-valid"),
+			},
+			expected: expected{
+				err: env.FieldValidationError{
+					EnvVar:  "OBOT_GITHUB_AUTH_PROVIDER_ORG",
+					Message: "must be 39 characters or less, got 50 characters",
+					Value:   "this-organization-name-is-way-too-long-to-be-valid",
+				},
+			},
+		},
+		{
+			name: "GitHub org invalid characters",
+			input: options{
+				ClientID:                 "client123",
+				ClientSecret:             "secret456",
+				ObotServerURL:            "https://example.com",
+				AuthCookieSecret:         "cookiesecret",
+				AuthEmailDomains:         "*",
+				AuthTokenRefreshDuration: "1h",
+				GitHubOrg:                ptr("invalid_org"),
+			},
+			expected: expected{
+				err: env.FieldValidationError{
+					EnvVar:  "OBOT_GITHUB_AUTH_PROVIDER_ORG",
+					Message: "is not a valid GitHub organization login (must contain only alphanumeric characters and single hyphens, cannot start or end with hyphen)",
+					Value:   "invalid_org",
+				},
+			},
+		},
+		{
+			name: "GitHub org starts with hyphen",
+			input: options{
+				ClientID:                 "client123",
+				ClientSecret:             "secret456",
+				ObotServerURL:            "https://example.com",
+				AuthCookieSecret:         "cookiesecret",
+				AuthEmailDomains:         "*",
+				AuthTokenRefreshDuration: "1h",
+				GitHubOrg:                ptr("-invalid"),
+			},
+			expected: expected{
+				err: env.FieldValidationError{
+					EnvVar:  "OBOT_GITHUB_AUTH_PROVIDER_ORG",
+					Message: "is not a valid GitHub organization login (must contain only alphanumeric characters and single hyphens, cannot start or end with hyphen)",
+					Value:   "-invalid",
+				},
+			},
+		},
+		{
+			name: "GitHub org ends with hyphen",
+			input: options{
+				ClientID:                 "client123",
+				ClientSecret:             "secret456",
+				ObotServerURL:            "https://example.com",
+				AuthCookieSecret:         "cookiesecret",
+				AuthEmailDomains:         "*",
+				AuthTokenRefreshDuration: "1h",
+				GitHubOrg:                ptr("invalid-"),
+			},
+			expected: expected{
+				err: env.FieldValidationError{
+					EnvVar:  "OBOT_GITHUB_AUTH_PROVIDER_ORG",
+					Message: "is not a valid GitHub organization login (must contain only alphanumeric characters and single hyphens, cannot start or end with hyphen)",
+					Value:   "invalid-",
+				},
+			},
+		},
+		{
+			name: "valid GitHub org at max length",
+			input: options{
+				ClientID:                 "client123",
+				ClientSecret:             "secret456",
+				ObotServerURL:            "https://example.com",
+				AuthCookieSecret:         "cookiesecret",
+				AuthEmailDomains:         "*",
+				AuthTokenRefreshDuration: "1h",
+				GitHubOrg:                ptr("a23456789012345678901234567890123456789"), // exactly 39 chars
+			},
+			expected: expected{
+				completed: &Options{
+					options: options{
+						ClientID:                 "client123",
+						ClientSecret:             "secret456",
+						ObotServerURL:            "https://example.com",
+						AuthCookieSecret:         "cookiesecret",
+						AuthEmailDomains:         "*",
+						AuthTokenRefreshDuration: "1h",
+						GitHubOrg:                ptr("a23456789012345678901234567890123456789"),
+					},
+					AuthEmailDomains:         []string{"*"},
+					AuthTokenRefreshDuration: 1 * time.Hour,
+					GitHubOrg:                "a23456789012345678901234567890123456789",
+				},
+			},
+		},
+		{
+			name: "empty GitHub users in comma-separated list",
+			input: options{
+				ClientID:                 "client123",
+				ClientSecret:             "secret456",
+				ObotServerURL:            "https://example.com",
+				AuthCookieSecret:         "cookiesecret",
+				AuthEmailDomains:         "*",
+				AuthTokenRefreshDuration: "1h",
+				GitHubAllowUsers:         ptr("user1,,user2"),
+			},
+			expected: expected{
+				err: env.FieldValidationError{
+					EnvVar:  "OBOT_GITHUB_AUTH_PROVIDER_ALLOW_USERS",
+					Message: "cannot contain empty users",
+					Value:   "user1,,user2",
+				},
+			},
+		},
+		{
+			name: "GitHub user too long",
+			input: options{
+				ClientID:                 "client123",
+				ClientSecret:             "secret456",
+				ObotServerURL:            "https://example.com",
+				AuthCookieSecret:         "cookiesecret",
+				AuthEmailDomains:         "*",
+				AuthTokenRefreshDuration: "1h",
+				GitHubAllowUsers:         ptr("this-username-is-way-too-long-to-be-valid"),
+			},
+			expected: expected{
+				err: env.FieldValidationError{
+					EnvVar:  "OBOT_GITHUB_AUTH_PROVIDER_ALLOW_USERS",
+					Message: "user 'this-username-is-way-too-long-to-be-valid' must be 39 characters or less, got 41 characters",
+					Value:   "this-username-is-way-too-long-to-be-valid",
+				},
+			},
+		},
+		{
+			name: "GitHub user invalid characters",
+			input: options{
+				ClientID:                 "client123",
+				ClientSecret:             "secret456",
+				ObotServerURL:            "https://example.com",
+				AuthCookieSecret:         "cookiesecret",
+				AuthEmailDomains:         "*",
+				AuthTokenRefreshDuration: "1h",
+				GitHubAllowUsers:         ptr("invalid_user"),
+			},
+			expected: expected{
+				err: env.FieldValidationError{
+					EnvVar:  "OBOT_GITHUB_AUTH_PROVIDER_ALLOW_USERS",
+					Message: "user 'invalid_user' is not a valid GitHub username (must contain only alphanumeric characters and single hyphens, cannot start or end with hyphen)",
+					Value:   "invalid_user",
+				},
+			},
+		},
+		{
+			name: "valid GitHub user at max length",
+			input: options{
+				ClientID:                 "client123",
+				ClientSecret:             "secret456",
+				ObotServerURL:            "https://example.com",
+				AuthCookieSecret:         "cookiesecret",
+				AuthEmailDomains:         "*",
+				AuthTokenRefreshDuration: "1h",
+				GitHubAllowUsers:         ptr("u23456789012345678901234567890123456789"), // exactly 39 chars
+			},
+			expected: expected{
+				completed: &Options{
+					options: options{
+						ClientID:                 "client123",
+						ClientSecret:             "secret456",
+						ObotServerURL:            "https://example.com",
+						AuthCookieSecret:         "cookiesecret",
+						AuthEmailDomains:         "*",
+						AuthTokenRefreshDuration: "1h",
+						GitHubAllowUsers:         ptr("u23456789012345678901234567890123456789"),
+					},
+					AuthEmailDomains:         []string{"*"},
+					AuthTokenRefreshDuration: 1 * time.Hour,
+					GitHubAllowUsers:         []string{"u23456789012345678901234567890123456789"},
+				},
+			},
+		},
+		{
+			name: "whitespace trimming in domains and users",
+			input: options{
+				ClientID:                 "client123",
+				ClientSecret:             "secret456",
+				ObotServerURL:            "https://example.com",
+				AuthCookieSecret:         "cookiesecret",
+				AuthEmailDomains:         " example.com , test.org ",
+				AuthTokenRefreshDuration: "1h",
+				GitHubOrg:                ptr("myorg"),
+				GitHubAllowUsers:         ptr(" user1 , user2 "),
+			},
+			expected: expected{
+				completed: &Options{
+					options: options{
+						ClientID:                 "client123",
+						ClientSecret:             "secret456",
+						ObotServerURL:            "https://example.com",
+						AuthCookieSecret:         "cookiesecret",
+						AuthEmailDomains:         " example.com , test.org ",
+						AuthTokenRefreshDuration: "1h",
+						GitHubOrg:                ptr("myorg"),
+						GitHubAllowUsers:         ptr(" user1 , user2 "),
+					},
+					AuthEmailDomains:         []string{"example.com", "test.org"},
+					AuthTokenRefreshDuration: 1 * time.Hour,
+					GitHubOrg:                "myorg",
+					GitHubAllowUsers:         []string{"user1", "user2"},
+				},
+			},
+		},
+		{
+			name: "zero values - nil pointers",
+			input: options{
+				ClientID:                 "client123",
+				ClientSecret:             "secret456",
+				ObotServerURL:            "https://example.com",
+				AuthCookieSecret:         "cookiesecret",
+				AuthEmailDomains:         "",
+				AuthTokenRefreshDuration: "30m",
+				GitHubOrg:                nil,
+				GitHubAllowUsers:         nil,
+			},
+			expected: expected{
+				completed: &Options{
+					options: options{
+						ClientID:                 "client123",
+						ClientSecret:             "secret456",
+						ObotServerURL:            "https://example.com",
+						AuthCookieSecret:         "cookiesecret",
+						AuthEmailDomains:         "",
+						AuthTokenRefreshDuration: "30m",
+					},
+					AuthTokenRefreshDuration: 30 * time.Minute,
+				},
+			},
+		},
+		{
+			name: "zero values - empty string pointers",
+			input: options{
+				ClientID:                 "client123",
+				ClientSecret:             "secret456",
+				ObotServerURL:            "https://example.com",
+				AuthCookieSecret:         "cookiesecret",
+				AuthEmailDomains:         "*",
+				AuthTokenRefreshDuration: "45m",
+				GitHubOrg:                ptr(""),
+				GitHubAllowUsers:         ptr(""),
+			},
+			expected: expected{
+				completed: &Options{
+					options: options{
+						ClientID:                 "client123",
+						ClientSecret:             "secret456",
+						ObotServerURL:            "https://example.com",
+						AuthCookieSecret:         "cookiesecret",
+						AuthEmailDomains:         "*",
+						AuthTokenRefreshDuration: "45m",
+						GitHubOrg:                ptr(""),
+						GitHubAllowUsers:         ptr(""),
+					},
+					AuthEmailDomains:         []string{"*"},
+					AuthTokenRefreshDuration: 45 * time.Minute,
+				},
+			},
+		},
+		{
+			name: "complex domain validation with punycode",
+			input: options{
+				ClientID:                 "client123",
+				ClientSecret:             "secret456",
+				ObotServerURL:            "https://example.com",
+				AuthCookieSecret:         "cookiesecret",
+				AuthEmailDomains:         "xn--n3h.com", // valid punycode
+				AuthTokenRefreshDuration: "1h",
+			},
+			expected: expected{
+				completed: &Options{
+					options: options{
+						ClientID:                 "client123",
+						ClientSecret:             "secret456",
+						ObotServerURL:            "https://example.com",
+						AuthCookieSecret:         "cookiesecret",
+						AuthEmailDomains:         "xn--n3h.com",
+						AuthTokenRefreshDuration: "1h",
+					},
+					AuthEmailDomains:         []string{"xn--n3h.com"},
+					AuthTokenRefreshDuration: 1 * time.Hour,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := complete(tt.input)
+
+			if tt.expected.err != nil {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expected.err.Error())
+				assert.Nil(t, result)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, result)
+				assert.Equal(t, tt.expected.completed, result)
+			}
+		})
+	}
+}
+
+func ptr[T any](v T) *T {
+	return &v
+}

--- a/github-auth-provider/tool.gpt
+++ b/github-auth-provider/tool.gpt
@@ -66,3 +66,9 @@ Credential: ../placeholder-credential as github-auth-provider
         }
     ]
 }
+
+---
+Name: validate
+Description: Validate GitHub Provider Configuration
+
+#!${GPTSCRIPT_TOOL_DIR}/bin/gptscript-go-tool validate


### PR DESCRIPTION
Add a `validate` tool that can be used to validate options passed to the github-auth-provider.

The tool validates each option field and returns a JSON object containing any validation errors it encountered. Each error in the response is keyed to the associated field name with the goal of driving better form UX in Obot's UI.

Addresses part of https://github.com/obot-platform/obot/issues/4039

See https://github.com/obot-platform/obot/pull/4044 for usage and loom.


