### PR TITLE
fix: use an in-memory cache to speed up github obot-get-state calls

### DIFF
--- a/github-auth-provider/go.mod
+++ b/github-auth-provider/go.mod
@@ -10,8 +10,10 @@ replace (
 )
 
 require (
+	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/oauth2-proxy/oauth2-proxy/v7 v7.8.1
 	github.com/obot-platform/tools/auth-providers-common v0.0.0-20241008222508-3c6174b443e7
+	github.com/sahilm/fuzzy v0.1.1
 )
 
 require (
@@ -62,7 +64,6 @@ require (
 	github.com/redis/go-redis/v9 v9.7.3 // indirect
 	github.com/sagikazarmark/locafero v0.7.0 // indirect
 	github.com/sagikazarmark/slog-shim v0.1.0 // indirect
-	github.com/sahilm/fuzzy v0.1.1 // indirect
 	github.com/sourcegraph/conc v0.3.0 // indirect
 	github.com/spf13/afero v1.12.0 // indirect
 	github.com/spf13/cast v1.7.1 // indirect

--- a/github-auth-provider/go.sum
+++ b/github-auth-provider/go.sum
@@ -76,6 +76,8 @@ github.com/googleapis/gax-go/v2 v2.14.1 h1:hb0FFeiPaQskmvakKu5EbCbpntQn48jyHuvrk
 github.com/googleapis/gax-go/v2 v2.14.1/go.mod h1:Hb/NubMaVM88SrNkvl8X/o8XWwDJEPqouaLeN2IUxoA=
 github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
 github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=
+github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
+github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=


### PR DESCRIPTION
The `github-auth-provider`'s `/obot-get-state` handler must make an additional GitHub API call to enrich the session state returned from OAuth2Proxy with the user's GitHub ID. This extra API call was seriously slowing down Obot's authentication.

This change speeds up the `/obot-get-state` handler by storing the user IDs returned from this call in an in-memory cache, and using cached IDs when available instead of hitting the GitHub API for subsequent requests.

It employs an LRU cache of fixed capacity -- 5000 to start, but we can make that configurable -- to map `(username, email) -> user_id`. This means that when a username or email changes for a user, `/obot-get-state` will
create a new cache entry and serve that going forward. Cache entries are evicted after an hour of inactivity.

*Caveat*: The capacity of the cache puts an implicit limit on the number of concurrent users Obot can handle before performance starts to degrade. We can adjust the capacity or make it configurable to address this.

Testing locally in docker, this change reduces the round-trip latency of `/obot-get-state` from ~170ms (on the initial request, uncached) to <1ms (cached); my browser's network inspector clocked `/api/version` and `/api/me` calls made from the `/admin/mcp-servers` page in the range of 10 to 75ms.

Loom https://www.loom.com/share/7fc8b85b85a34b32a75bde02baf47cdd?sid=4f62efa8-d7d4-4758-bcd7-64d7ee5b7a6b

Addresses https://github.com/obot-platform/obot/issues/3998
