### PR TITLE
enhance: return id token from get state

### DIFF
--- a/auth-providers-common/pkg/state/state.go
+++ b/auth-providers-common/pkg/state/state.go
@@ -34,6 +34,7 @@ type SerializableRequest struct {
 type SerializableState struct {
 	ExpiresOn         *time.Time    `json:"expiresOn"`
 	AccessToken       string        `json:"accessToken"`
+	IDToken           string        `json:"idToken"`
 	PreferredUsername string        `json:"preferredUsername"`
 	User              string        `json:"user"`
 	Email             string        `json:"email"`
@@ -92,6 +93,7 @@ func GetSerializableState(p *oauth2proxy.OAuthProxy, r *http.Request) (Serializa
 	return SerializableState{
 		ExpiresOn:         state.ExpiresOn,
 		AccessToken:       state.AccessToken,
+		IDToken:           state.IDToken,
 		PreferredUsername: state.PreferredUsername,
 		User:              state.User,
 		Email:             state.Email,


### PR DESCRIPTION
Return the OIDC ID token when getting the state from an oauth provider.
This exposes the ID token to dependent auth provider implementations
so they can extract whatever info they need from them.
