### PR TITLE
Enhance: Hide certain tools when using bot token

### DIFF
--- a/slack/package-lock.json
+++ b/slack/package-lock.json
@@ -7,7 +7,7 @@
         "": {
             "name": "@obot-platform/slack-mcp",
             "version": "0.0.1",
-            "license": "MIT",
+            "license": "Apache-2.0",
             "dependencies": {
                 "@modelcontextprotocol/sdk": "1.12.3",
                 "@slack/web-api": "^7.9.1",


### PR DESCRIPTION
https://github.com/obot-platform/obot/issues/4137
https://github.com/obot-platform/obot/issues/4138

We should hide certain tools when using a bot token. Search message is not available in bot, and also get dm history between a bot and user doesn't often make senses.