### PR TITLE
Add Dialect to model providers

### DIFF
--- a/anthropic-model-provider-go/tool.gpt
+++ b/anthropic-model-provider-go/tool.gpt
@@ -13,6 +13,7 @@ Metadata: noUserAuth: anthropic-model-provider
     "icon": "/admin/assets/anthropic_icon.svg",
     "link": "https://www.anthropic.com",
     "description": "Note: Anthropic does not have an embeddings model and [recommends](https://docs.anthropic.com/en/docs/build-with-claude/embeddings) Voyage AI.",
+    "dialect": "AnthropicMessages",
     "envVars": [
         {
             "name": "OBOT_ANTHROPIC_MODEL_PROVIDER_API_KEY",

--- a/ollama-model-provider/go.mod
+++ b/ollama-model-provider/go.mod
@@ -5,5 +5,3 @@ go 1.26.2
 replace github.com/obot-platform/tools/openai-model-provider => ../openai-model-provider
 
 require github.com/obot-platform/tools/openai-model-provider v0.0.0
-
-require github.com/gptscript-ai/chat-completion-client v0.0.0-20250123123106-c86554320789 // indirect

--- a/ollama-model-provider/go.sum
+++ b/ollama-model-provider/go.sum
@@ -1,2 +1,0 @@
-github.com/gptscript-ai/chat-completion-client v0.0.0-20250123123106-c86554320789 h1:rfriXe+FFqZ5fZ+wGzLUivrq7Fyj2xfRdZjDsHf6Ps0=
-github.com/gptscript-ai/chat-completion-client v0.0.0-20250123123106-c86554320789/go.mod h1:7P/o6/IWa1KqsntVf68hSnLKuu3+xuqm6lYhch1w4jo=

--- a/ollama-model-provider/tool.gpt
+++ b/ollama-model-provider/tool.gpt
@@ -11,6 +11,7 @@ Metadata: noUserAuth: ollama-model-provider
 {
     "icon": "https://ollama.com/public/ollama.png",
     "link": "https://ollama.com/",
+    "dialect": "OpenResponses",
     "envVars": [
         {
             "name": "OBOT_OLLAMA_MODEL_PROVIDER_HOST",

--- a/openai-model-provider/tool.gpt
+++ b/openai-model-provider/tool.gpt
@@ -11,6 +11,7 @@ Metadata: noUserAuth: openai-model-provider
 {
     "icon": "https://cdn.jsdelivr.net/npm/@phosphor-icons/core@2/assets/duotone/open-ai-logo-duotone.svg",
     "link": "https://openai.com/",
+    "dialect": "OpenAIResponses",
     "envVars": [
         {
             "name": "OBOT_OPENAI_MODEL_PROVIDER_API_KEY",


### PR DESCRIPTION
Adds a `dialect` field to the `providerMeta` metadata for the Anthropic and OpenAI model providers.

- **anthropic-model-provider-go**: `"dialect": "AnthropicMessages"`
- **openai-model-provider**: `"dialect": "OpenAIResponses"`

This PR is optional — Obot falls back to defaults when it is absent. However, it is recommended for full forward compatibility and consistency with additional model providers that will declare their own dialects.

Depends on obot-platform/obot#6246 and nanobot-ai/nanobot#263.