### PR TITLE
feat: Add Generic Responses model provider

### DIFF
--- a/anthropic-model-provider-go/main.go
+++ b/anthropic-model-provider-go/main.go
@@ -40,7 +40,7 @@ func main() {
 			header.Set("x-api-key", cfg.APIKey)
 			header.Set("anthropic-version", "2023-06-01")
 		}
-		if err := cfg.Validate("/tools/anthropic-model-provider/validate"); err != nil {
+		if err := cfg.Validate(); err != nil {
 			os.Exit(1)
 		}
 	}

--- a/deepseek-model-provider/main.go
+++ b/deepseek-model-provider/main.go
@@ -23,7 +23,7 @@ func main() {
 	}
 
 	if len(os.Args) > 1 && os.Args[1] == "validate" {
-		if err := cfg.Validate("/tools/deepseek-model-provider/validate"); err != nil {
+		if err := cfg.Validate(); err != nil {
 			os.Exit(1)
 		}
 		return

--- a/generic-openai-model-provider/main.go
+++ b/generic-openai-model-provider/main.go
@@ -41,7 +41,7 @@ func main() {
 		Name:                 "Generic OpenAI",
 	}
 
-	if err := cfg.Validate("/tools/generic-openai-model-provider/validate"); err != nil {
+	if err := cfg.Validate(); err != nil {
 		os.Exit(1)
 	}
 

--- a/generic-responses-model-provider/go.mod
+++ b/generic-responses-model-provider/go.mod
@@ -1,0 +1,7 @@
+module github.com/obot-platform/tools/generic-responses-model-provider
+
+go 1.26.2
+
+replace github.com/obot-platform/tools/openai-model-provider => ../openai-model-provider
+
+require github.com/obot-platform/tools/openai-model-provider v0.0.0

--- a/generic-responses-model-provider/main.go
+++ b/generic-responses-model-provider/main.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/obot-platform/tools/openai-model-provider/proxy"
+)
+
+func main() {
+	isValidate := len(os.Args) > 1 && os.Args[1] == "validate"
+
+	cfg := &proxy.Config{
+		APIKey:          os.Getenv("OBOT_GENERIC_RESPONSES_MODEL_PROVIDER_API_KEY"), // optional
+		ListenPort:      os.Getenv("PORT"),
+		BaseURL:         os.Getenv("OBOT_GENERIC_RESPONSES_MODEL_PROVIDER_BASE_URL"),
+		RewriteModelsFn: proxy.RewriteAllModelsWithUsage("llm"),
+		Name:            "Generic Responses",
+	}
+
+	if isValidate {
+		if err := cfg.Validate(); err != nil {
+			os.Exit(1)
+		}
+		return
+	}
+
+	if err := proxy.Run(cfg); err != nil {
+		fmt.Printf("failed to run generic-responses-model-provider proxy: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/generic-responses-model-provider/tool.gpt
+++ b/generic-responses-model-provider/tool.gpt
@@ -1,0 +1,39 @@
+Name: Responses Compatible Generic Provider
+Description: Model Provider for generic Responses API compatible model providers, including Ollama and LiteLLM
+Model Provider: true
+Credential: ../placeholder-credential as generic-responses-model-provider with OBOT_GENERIC_RESPONSES_MODEL_PROVIDER_BASE_URL;OBOT_GENERIC_RESPONSES_MODEL_PROVIDER_API_KEY as env_vars
+Metadata: noUserAuth: generic-responses-model-provider
+
+#!sys.daemon ${GPTSCRIPT_TOOL_DIR}/bin/gptscript-go-tool
+
+---
+!metadata:Responses Compatible Generic Provider:providerMeta
+{
+    "icon": "/admin/assets/obot_openai_antenna_icon.png",
+    "iconDark": "/admin/assets/obot_openai_antenna_icon.png",
+    "link": "https://www.openresponses.org",
+    "dialect": "OpenResponses",
+    "description": "Model Provider for generic [Responses API compatible](https://www.openresponses.org) model providers, like [Ollama](https://ollama.com/) (`http://127.0.0.1:11434/v1`), LiteLLM, etc.",
+    "envVars": [
+        {
+            "name": "OBOT_GENERIC_RESPONSES_MODEL_PROVIDER_BASE_URL",
+            "friendlyName": "Base URL",
+            "description": "Base URL for the OpenAI Responses-compatible API (e.g. http://127.0.0.1:11434/v1 for Ollama).",
+            "sensitive": false
+        }
+    ],
+    "optionalEnvVars": [
+        {
+            "name": "OBOT_GENERIC_RESPONSES_MODEL_PROVIDER_API_KEY",
+            "friendlyName": "API Key",
+            "description": "API Key for the OpenAI Responses-compatible API. Some providers like Ollama don't enforce Authentication, so this is optional.",
+            "sensitive": true
+        }
+    ]
+}
+
+---
+Name: validate
+Description: Validate the generic Responses API configuration
+
+#!${GPTSCRIPT_TOOL_DIR}/bin/gptscript-go-tool validate

--- a/groq-model-provider/main.go
+++ b/groq-model-provider/main.go
@@ -23,7 +23,7 @@ func main() {
 	}
 
 	if len(os.Args) > 1 && os.Args[1] == "validate" {
-		if err := cfg.Validate("/tools/groq-model-provider/validate"); err != nil {
+		if err := cfg.Validate(); err != nil {
 			os.Exit(1)
 		}
 		return

--- a/index.yaml
+++ b/index.yaml
@@ -49,6 +49,8 @@ modelProviders:
     reference: ./anthropic-model-provider-go
   ollama-model-provider:
     reference: ./ollama-model-provider
+  generic-responses-model-provider:
+    reference: ./generic-responses-model-provider
   groq-model-provider:
     reference: ./groq-model-provider
   vllm-model-provider:

--- a/ollama-model-provider/main.go
+++ b/ollama-model-provider/main.go
@@ -47,7 +47,7 @@ func main() {
 	}
 
 	if len(os.Args) > 1 && os.Args[1] == "validate" {
-		if err := cfg.Validate("/tools/ollama-model-provider/validate"); err != nil {
+		if err := cfg.Validate(); err != nil {
 			os.Exit(1)
 		}
 		return

--- a/openai-model-provider/main.go
+++ b/openai-model-provider/main.go
@@ -37,7 +37,7 @@ func main() {
 	}).ServeHTTP
 
 	if len(os.Args) > 1 && os.Args[1] == "validate" {
-		if err := cfg.Validate("/tools/openai-model-provider/validate"); err != nil {
+		if err := cfg.Validate(); err != nil {
 			os.Exit(1)
 		}
 		return

--- a/openai-model-provider/proxy/proxy.go
+++ b/openai-model-provider/proxy/proxy.go
@@ -59,8 +59,10 @@ func (cfg *Config) EnsureURL() error {
 		return nil
 	}
 
-	// Remove any trailing slashes from BaseURL
-	cfg.BaseURL = strings.TrimRight(cfg.BaseURL, "/")
+	cfg.BaseURL = strings.TrimRight(strings.TrimSpace(cfg.BaseURL), "/")
+	if cfg.BaseURL == "" {
+		return errors.New("base URL cannot be empty or '/'")
+	}
 
 	u, err := url.Parse(cfg.BaseURL)
 	if err != nil {

--- a/openai-model-provider/proxy/validate.go
+++ b/openai-model-provider/proxy/validate.go
@@ -2,30 +2,57 @@ package proxy
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
-	"log/slog"
+	"log"
 	"net/http"
+	"os"
+	"strings"
 
 	"github.com/obot-platform/tools/openai-model-provider/api"
 )
 
-func handleValidationError(err error, loggerPath, msg string) error {
-	slog.Error(msg, "logger", loggerPath, "error", err)
-	fmt.Printf("{\"error\": \"%s\"}\n", msg)
-	return fmt.Errorf(msg)
+type upstreamErrorResponse struct {
+	Error struct {
+		Message string `json:"message"`
+	} `json:"error"`
 }
 
-func (cfg *Config) Validate(toolPath string) error {
+func handleValidationError(err error, msg string) error {
+	log.Printf("ERROR Invalid: %v", err)
+	if msg == "" && err != nil {
+		msg = err.Error()
+	}
+	errorJSON := map[string]string{"error": msg}
+	if encErr := json.NewEncoder(os.Stdout).Encode(errorJSON); encErr != nil {
+		return encErr
+	}
+	return errors.New(msg)
+}
+
+func parseUpstreamErrorMessage(body []byte) string {
+	var upstreamErr upstreamErrorResponse
+	if err := json.Unmarshal(body, &upstreamErr); err != nil {
+		return ""
+	}
+	if strings.Contains(upstreamErr.Error.Message, "Incorrect API key provided") || // OpenAI error
+		strings.Contains(upstreamErr.Error.Message, "invalid x-api-key") { // Anthropic error
+		return "Invalid API Key"
+	}
+	return upstreamErr.Error.Message
+}
+
+func (cfg *Config) Validate() error {
 	if err := cfg.EnsureURL(); err != nil {
-		return fmt.Errorf("failed to ensure URL: %w", err)
+		return handleValidationError(err, "")
 	}
 
 	url := cfg.URL.JoinPath("/models")
 
 	req, err := http.NewRequest("GET", url.String(), nil)
 	if err != nil {
-		return handleValidationError(err, toolPath, fmt.Sprintf("Invalid %s Configuration", cfg.Name))
+		return handleValidationError(err, "")
 	}
 
 	req.Header.Set("Authorization", "Bearer "+cfg.APIKey)
@@ -38,25 +65,34 @@ func (cfg *Config) Validate(toolPath string) error {
 	client := &http.Client{}
 	resp, err := client.Do(req)
 	if err != nil {
-		return handleValidationError(err, toolPath, fmt.Sprintf("Invalid %s Configuration", cfg.Name))
+		return handleValidationError(err, "")
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
+		body := []byte(nil)
 		if resp.Body != nil {
-			body, _ := io.ReadAll(resp.Body)
-			return handleValidationError(fmt.Errorf("status %s: %s", resp.Status, string(body)), toolPath, fmt.Sprintf("Invalid %s Credentials", cfg.Name))
+			if bodyBytes, readErr := io.ReadAll(io.LimitReader(resp.Body, 4096)); readErr == nil {
+				body = bodyBytes
+			}
 		}
-		return handleValidationError(fmt.Errorf("status %s", resp.Status), toolPath, fmt.Sprintf("Invalid %s Credentials", cfg.Name))
+
+		// Log the status and full body, but only include upstreamMsg or simplified status in the user-facing error
+		bodyErr := fmt.Errorf("status %s: %s", resp.Status, string(body))
+		msg := parseUpstreamErrorMessage(body)
+		if msg == "" {
+			msg = fmt.Sprintf("status: %s", resp.Status)
+		}
+		return handleValidationError(bodyErr, msg)
 	}
 
 	var modelsResp api.ModelsResponse
 	if err := json.NewDecoder(resp.Body).Decode(&modelsResp); err != nil {
-		return handleValidationError(err, toolPath, "Invalid Response Format")
+		return handleValidationError(err, "Invalid Response Format")
 	}
 
 	if modelsResp.Object != "" && modelsResp.Object != "list" || len(modelsResp.Data) == 0 {
-		return handleValidationError(nil, toolPath, fmt.Sprintf("Invalid Models Response: %d models", len(modelsResp.Data)))
+		return handleValidationError(nil, fmt.Sprintf("Invalid Models Response: %d models", len(modelsResp.Data)))
 	}
 
 	return nil

--- a/openai-model-provider/proxy/validate_test.go
+++ b/openai-model-provider/proxy/validate_test.go
@@ -1,0 +1,156 @@
+package proxy
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+)
+
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("create stdout pipe: %v", err)
+	}
+	os.Stdout = w
+
+	outCh := make(chan []byte, 1)
+	go func() {
+		buf, _ := io.ReadAll(r)
+		outCh <- buf
+	}()
+
+	fn()
+
+	_ = w.Close()
+	os.Stdout = orig
+	buf := <-outCh
+	_ = r.Close()
+
+	return string(buf)
+}
+
+func decodeErrorJSON(t *testing.T, out string) string {
+	t.Helper()
+
+	var body map[string]string
+	if err := json.NewDecoder(bytes.NewBufferString(out)).Decode(&body); err != nil {
+		t.Fatalf("decode stdout JSON: %v (raw: %q)", err, out)
+	}
+	return body["error"]
+}
+
+func captureLogOutput(t *testing.T, fn func()) string {
+	t.Helper()
+
+	origWriter := log.Writer()
+	origFlags := log.Flags()
+	origPrefix := log.Prefix()
+
+	var b bytes.Buffer
+	log.SetOutput(&b)
+	log.SetFlags(0)
+	log.SetPrefix("")
+
+	defer func() {
+		log.SetOutput(origWriter)
+		log.SetFlags(origFlags)
+		log.SetPrefix(origPrefix)
+	}()
+
+	fn()
+	return b.String()
+}
+
+func TestValidate_ErrorResponses(t *testing.T) {
+	tests := []struct {
+		name         string
+		statusCode   int
+		responseBody string
+		expectedErr  string
+		expectedLogs []string
+	}{
+		{
+			name:         "uses upstream invalid key message",
+			statusCode:   http.StatusUnauthorized,
+			responseBody: `{"error":{"message":"Incorrect API key provided: bad-key"}}`,
+			expectedErr:  "Invalid API Key",
+			expectedLogs: []string{
+				"ERROR Invalid: status 401 Unauthorized",
+				"Incorrect API key provided: bad-key",
+			},
+		},
+		{
+			name:         "falls back to status when body not parseable",
+			statusCode:   http.StatusBadGateway,
+			responseBody: "not-json",
+			expectedErr:  "status: 502 Bad Gateway",
+			expectedLogs: []string{
+				"ERROR Invalid: status 502 Bad Gateway: not-json",
+			},
+		},
+		{
+			name:         "uses parseable non-auth upstream error message",
+			statusCode:   http.StatusTooManyRequests,
+			responseBody: `{"error":{"message":"rate limit exceeded"}}`,
+			expectedErr:  "rate limit exceeded",
+			expectedLogs: []string{
+				"ERROR Invalid: status 429 Too Many Requests",
+				"rate limit exceeded",
+			},
+		},
+		{
+			name:         "maps invalid x-api-key to invalid api key",
+			statusCode:   http.StatusUnauthorized,
+			responseBody: `{"error":{"message":"invalid x-api-key"}}`,
+			expectedErr:  "Invalid API Key",
+			expectedLogs: []string{
+				"ERROR Invalid: status 401 Unauthorized",
+				"invalid x-api-key",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tt.statusCode)
+				_, _ = w.Write([]byte(tt.responseBody))
+			}))
+			t.Cleanup(ts.Close)
+
+			cfg := &Config{BaseURL: ts.URL, APIKey: "test-key"}
+
+			var err error
+			var logs string
+			out := captureStdout(t, func() {
+				logs = captureLogOutput(t, func() {
+					err = cfg.Validate()
+				})
+			})
+
+			if err == nil {
+				t.Fatal("expected validation error")
+			}
+			if got := err.Error(); got != tt.expectedErr {
+				t.Fatalf("unexpected returned error: %q", got)
+			}
+			if got := decodeErrorJSON(t, out); got != tt.expectedErr {
+				t.Fatalf("unexpected stdout error JSON: %q", got)
+			}
+			for _, expectedLog := range tt.expectedLogs {
+				if !strings.Contains(logs, expectedLog) {
+					t.Fatalf("expected log to contain %q, got: %q", expectedLog, logs)
+				}
+			}
+		})
+	}
+}

--- a/vllm-model-provider/main.go
+++ b/vllm-model-provider/main.go
@@ -50,7 +50,7 @@ func main() {
 	}
 
 	if len(os.Args) > 1 && os.Args[1] == "validate" {
-		if err := cfg.Validate("/tools/vllm-model-provider/validate"); err != nil {
+		if err := cfg.Validate(); err != nil {
 			os.Exit(1)
 		}
 		return

--- a/xai-model-provider/main.go
+++ b/xai-model-provider/main.go
@@ -38,7 +38,7 @@ func main() {
 	}
 
 	if len(os.Args) > 1 && os.Args[1] == "validate" {
-		if err := cfg.Validate("/tools/xai-model-provider/validate"); err != nil {
+		if err := cfg.Validate(); err != nil {
 			os.Exit(1)
 		}
 		return


### PR DESCRIPTION
Addresses https://github.com/obot-platform/obot/issues/6506

Rename Ollama model provider to Generic Responses and add optional API Key.

Also addresses https://github.com/obot-platform/obot/issues/6410 since errors were not working correctly for the new provider. This puts error handling more inline with the enterprise tools.

<img width="695" height="546" alt="Screenshot 2026-05-06 at 16 06 04" src="https://github.com/user-attachments/assets/0e8ccc9c-2a5c-433a-abb1-59ae0751ab6e" />
<img width="685" height="443" alt="Screenshot 2026-05-07 at 08 08 27" src="https://github.com/user-attachments/assets/837ae9e1-b7fa-4ea5-9b07-8d97281080fb" />
<img width="689" height="390" alt="Screenshot 2026-05-07 at 08 11 49" src="https://github.com/user-attachments/assets/18439cf1-996b-4457-9477-e8984c4fcb18" />
<img width="680" height="541" alt="Screenshot 2026-05-07 at 08 12 03" src="https://github.com/user-attachments/assets/405da014-0612-4b1e-b5b4-055d21ebc301" />
